### PR TITLE
feat: add command aliases

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -35,6 +35,17 @@ class SwitchCoder(Exception):
 class Commands:
     scraper = None
 
+    # Command aliases mapping (alias -> full command name)
+    COMMAND_ALIASES = {
+        "/a": "/add",
+        "/c": "/commit",
+        "/d": "/drop",
+        "/u": "/undo",
+        "/h": "/help",
+        "/q": "/quit",
+        "/r": "/reset",
+    }
+
     def clone(self):
         return Commands(
             self.io,
@@ -241,11 +252,11 @@ class Commands:
             )
 
         content = self.scraper.scrape(url)
-        
+
         # If scraping failed, don't add empty content to chat
         if not content:
             return None if return_content else None
-        
+
         content = f"Here is the content of {url}:\n\n" + content
         if return_content:
             return content
@@ -287,6 +298,9 @@ class Commands:
             cmd = cmd.replace("_", "-")
             commands.append("/" + cmd)
 
+        # Add aliases to the command list
+        commands.extend(self.COMMAND_ALIASES.keys())
+
         return commands
 
     def do_run(self, cmd_name, args):
@@ -310,8 +324,17 @@ class Commands:
         first_word = words[0]
         rest_inp = inp[len(words[0]) :].strip()
 
+        # Resolve alias if present
+        resolved_first_word = self.COMMAND_ALIASES.get(first_word, first_word)
+
         all_commands = self.get_commands()
+        # Match against both original input and resolved alias
         matching_commands = [cmd for cmd in all_commands if cmd.startswith(first_word)]
+
+        # If first_word is an alias, also include the resolved command
+        if first_word in self.COMMAND_ALIASES and resolved_first_word not in matching_commands:
+            matching_commands.append(resolved_first_word)
+
         return matching_commands, first_word, rest_inp
 
     def run(self, inp):
@@ -323,8 +346,17 @@ class Commands:
         if res is None:
             return
         matching_commands, first_word, rest_inp = res
+
+        # Resolve alias for execution
+        resolved_command = self.COMMAND_ALIASES.get(first_word, first_word)
+
         if len(matching_commands) == 1:
             command = matching_commands[0][1:]
+            self.coder.event(f"command_{command}")
+            return self.do_run(command, rest_inp)
+        elif first_word in self.COMMAND_ALIASES:
+            # Direct alias match - use resolved command
+            command = resolved_command[1:]
             self.coder.event(f"command_{command}")
             return self.do_run(command, rest_inp)
         elif first_word in matching_commands:
@@ -777,7 +809,7 @@ class Commands:
             else:
                 try:
                     raw_matched_files = list(Path(self.coder.root).glob(pattern))
-                except (IndexError, AttributeError):
+                except IndexError, AttributeError:
                     raw_matched_files = []
         except ValueError as err:
             self.io.tool_error(f"Error matching {pattern}: {err}")
@@ -934,7 +966,7 @@ class Commands:
                     abs_word = os.path.abspath(expanded_word)
                     if os.path.samefile(abs_word, f):
                         read_only_matched.append(f)
-                except (FileNotFoundError, OSError):
+                except FileNotFoundError, OSError:
                     continue
 
             for matched_file in read_only_matched:
@@ -964,6 +996,7 @@ class Commands:
         combined_output = None
         try:
             import shlex
+
             # Parse git arguments safely to prevent command injection
             git_args = ["git"] + shlex.split(args) if args.strip() else ["git"]
             env = dict(subprocess.os.environ)
@@ -1054,11 +1087,12 @@ class Commands:
         # Set shutdown flag to stop retry loops
         self.coder._shutdown_flag = True
         self.coder.event("exit", reason="/exit")
-        
+
         # Give a brief moment for cleanup
         import time
+
         time.sleep(0.1)
-        
+
         sys.exit()
 
     def cmd_quit(self, args):
@@ -1106,17 +1140,25 @@ class Commands:
 
     def basic_help(self):
         commands = sorted(self.get_commands())
-        pad = max(len(cmd) for cmd in commands)
+        # Separate aliases and regular commands
+        regular_commands = [cmd for cmd in commands if cmd not in self.COMMAND_ALIASES]
+
+        pad = max(len(cmd) for cmd in regular_commands)
         pad = "{cmd:" + str(pad) + "}"
-        for cmd in commands:
+        for cmd in regular_commands:
             cmd_method_name = f"cmd_{cmd[1:]}".replace("-", "_")
             cmd_method = getattr(self, cmd_method_name, None)
-            cmd = pad.format(cmd=cmd)
+            formatted_cmd = pad.format(cmd=cmd)
+
+            # Find aliases for this command
+            aliases = [alias for alias, full_cmd in self.COMMAND_ALIASES.items() if full_cmd == cmd]
+            alias_str = f" (alias: {', '.join(aliases)})" if aliases else ""
+
             if cmd_method:
                 description = cmd_method.__doc__
-                self.io.tool_output(f"{cmd} {description}")
+                self.io.tool_output(f"{formatted_cmd} {description}{alias_str}")
             else:
-                self.io.tool_output(f"{cmd} No description available.")
+                self.io.tool_output(f"{formatted_cmd} No description available.{alias_str}")
         self.io.tool_output()
         self.io.tool_output("Use `/help <question>` to ask questions about how to use atlas.")
 
@@ -1233,14 +1275,22 @@ class Commands:
 |:------|:----------|
 """
         commands = sorted(self.get_commands())
-        for cmd in commands:
+        # Separate aliases and regular commands
+        regular_commands = [cmd for cmd in commands if cmd not in self.COMMAND_ALIASES]
+
+        for cmd in regular_commands:
             cmd_method_name = f"cmd_{cmd[1:]}".replace("-", "_")
             cmd_method = getattr(self, cmd_method_name, None)
+
+            # Find aliases for this command
+            aliases = [alias for alias, full_cmd in self.COMMAND_ALIASES.items() if full_cmd == cmd]
+            cmd_display = f"{cmd}" + (f" (alias: {', '.join(aliases)})" if aliases else "")
+
             if cmd_method:
                 description = cmd_method.__doc__
-                res += f"| **{cmd}** | {description} |\n"
+                res += f"| **{cmd_display}** | {description} |\n"
             else:
-                res += f"| **{cmd}** | |\n"
+                res += f"| **{cmd_display}** | |\n"
 
         res += "\n"
         return res
@@ -1675,6 +1725,7 @@ def get_help_md():
 def count_commands():
     commands = [attr for attr in dir(Commands) if attr.startswith("cmd_")]
     return len(commands)
+
 
 def main():
     print(f"Number of command lines: {count_commands()}")

--- a/cli/io.py
+++ b/cli/io.py
@@ -29,8 +29,7 @@ from pygments.token import Token
 from rich.color import ColorParseError
 from rich.columns import Columns
 from rich.console import Console
-from rich.markdown import Markdown, CodeBlock
-from rich.panel import Panel
+from rich.markdown import Markdown
 from rich.style import Style as RichStyle
 from rich.text import Text
 from rich.theme import Theme
@@ -45,24 +44,26 @@ from cli.footer_hints import FooterHints
 NOTIFICATION_MESSAGE = "Atlas is waiting for your input"
 
 # Custom dark theme for markdown to avoid white backgrounds
-DARK_THEME = Theme({
-    # Use repr.str style for inline code (no white background)
-    "markdown.code": "#278ef5",  # Brand blue
-    "markdown.link": "#278ef5",  # Brand blue
-    "markdown.link_url": "#278ef5 underline",
-    "markdown.h1": "bold #278ef5",
-    "markdown.h2": "bold #278ef5",
-    "markdown.h3": "bold #278ef5",
-    "markdown.emph": "italic #278ef5",
-    "markdown.strong": "bold",
-    # List styles - use brand blue (#278ef5) instead of yellow
-    "markdown.list": "#278ef5",  # Brand blue for list items
-    "markdown.list.bullet": "#278ef5",  # Brand blue for bullet points
-    "markdown.list.number": "#278ef5",  # Brand blue for numbered list numbers
-    "markdown.item.bullet": "#278ef5",  # Brand blue for bullet characters
-    "markdown.item.number": "#278ef5",  # Brand blue for number characters
-    "": "",  # Default - no background
-})
+DARK_THEME = Theme(
+    {
+        # Use repr.str style for inline code (no white background)
+        "markdown.code": "#278ef5",  # Brand blue
+        "markdown.link": "#278ef5",  # Brand blue
+        "markdown.link_url": "#278ef5 underline",
+        "markdown.h1": "bold #278ef5",
+        "markdown.h2": "bold #278ef5",
+        "markdown.h3": "bold #278ef5",
+        "markdown.emph": "italic #278ef5",
+        "markdown.strong": "bold",
+        # List styles - use brand blue (#278ef5) instead of yellow
+        "markdown.list": "#278ef5",  # Brand blue for list items
+        "markdown.list.bullet": "#278ef5",  # Brand blue for bullet points
+        "markdown.list.number": "#278ef5",  # Brand blue for numbered list numbers
+        "markdown.item.bullet": "#278ef5",  # Brand blue for bullet characters
+        "markdown.item.number": "#278ef5",  # Brand blue for number characters
+        "": "",  # Default - no background
+    }
+)
 
 
 def ensure_hash_prefix(color):
@@ -155,7 +156,7 @@ class AutoCompleter(Completer):
             try:
                 with open(fname, "r", encoding=self.encoding) as f:
                     content = f.read()
-            except (FileNotFoundError, UnicodeDecodeError, IsADirectoryError):
+            except FileNotFoundError, UnicodeDecodeError, IsADirectoryError:
                 continue
             try:
                 lexer = guess_lexer_for_filename(fname, content)
@@ -185,7 +186,11 @@ class AutoCompleter(Completer):
         if len(matches) == 1:
             cmd = matches[0]
         elif cmd not in matches:
-            return
+            # Check if cmd is an alias
+            if hasattr(self.commands, "COMMAND_ALIASES") and cmd in self.commands.COMMAND_ALIASES:
+                cmd = self.commands.COMMAND_ALIASES[cmd]
+            else:
+                return
 
         raw_completer = self.commands.get_raw_completions(cmd)
         if raw_completer:
@@ -531,7 +536,7 @@ class InputOutput:
 
     def rule(self, show_footer=False):
         """Print a blank line instead of separator.
-        
+
         Args:
             show_footer: If True, show footer hints (no separator line)
         """
@@ -802,6 +807,7 @@ class InputOutput:
         if self.pretty and self.user_input_color:
             # Display with background using Rich style
             from rich.style import Style as RichStyle
+
             text = Text(f"> {inp}")
             text.stylize(RichStyle(color=self.user_input_color, bgcolor="#2b2b2b"))
             self.console.print(text)
@@ -846,39 +852,41 @@ class InputOutput:
         """
         from prompt_toolkit.shortcuts import radiolist_dialog
         from prompt_toolkit.styles import Style as PTKStyle
-        
+
         # Define options
         options = [
             (False, "Allow Atlas to work in this folder without asking for approval"),
             (True, "Require approval of edits and commands"),
         ]
-        
-        style = PTKStyle.from_dict({
-            'dialog': 'bg:#1E1E1E',
-            'dialog.body': 'bg:#1E1E1E #9CDCFE',
-            'dialog frame.label': 'bg:#3B82F6 #FFFFFF bold',
-            'dialog.body text': '#CCCCCC',
-            'dialog.body label': '#9CDCFE',
-            'radio-checked': '#4EC9B0 bold',
-            'radio': '#9CDCFE',
-        })
-        
+
+        style = PTKStyle.from_dict(
+            {
+                "dialog": "bg:#1E1E1E",
+                "dialog.body": "bg:#1E1E1E #9CDCFE",
+                "dialog frame.label": "bg:#3B82F6 #FFFFFF bold",
+                "dialog.body text": "#CCCCCC",
+                "dialog.body label": "#9CDCFE",
+                "radio-checked": "#4EC9B0 bold",
+                "radio": "#9CDCFE",
+            }
+        )
+
         try:
             result = radiolist_dialog(
                 title="Atlas Approval Mode",
                 text=f"You are running Atlas in {folder_path}\n\n"
-                     "Since this folder is not version controlled, we recommend requiring approval of all edits and commands.\n\n"
-                     "Use arrow keys to navigate, Enter to select:",
+                "Since this folder is not version controlled, we recommend requiring approval of all edits and commands.\n\n"
+                "Use arrow keys to navigate, Enter to select:",
                 values=options,
                 default=True,  # Default to "require approval"
                 style=style,
             ).run()
-            
+
             # result is True for "require approval", False for "auto mode"
             # We return the opposite of "require_approval" for easier logic
             return result
-            
-        except (KeyboardInterrupt, EOFError):
+
+        except KeyboardInterrupt, EOFError:
             # Default to require approval if user cancels
             return True
 
@@ -1172,20 +1180,18 @@ class InputOutput:
             if self.notifications_command:
                 try:
                     import shlex
+
                     # Parse command safely to prevent injection
                     # Notifications command should be a simple command from config
                     try:
                         cmd_parts = shlex.split(self.notifications_command)
-                        result = subprocess.run(
-                            cmd_parts, shell=False, capture_output=True
-                        )
+                        result = subprocess.run(cmd_parts, shell=False, capture_output=True)
                     except ValueError:
                         # If parsing fails, quote and use shell (less safe but handles edge cases)
                         import shlex
+
                         quoted_cmd = shlex.quote(self.notifications_command)
-                        result = subprocess.run(
-                            quoted_cmd, shell=True, capture_output=True
-                        )
+                        result = subprocess.run(quoted_cmd, shell=True, capture_output=True)
                     if result.returncode != 0 and result.stderr:
                         error_msg = result.stderr.decode("utf-8", errors="replace")
                         self.tool_warning(f"Failed to run notifications command: {error_msg}")


### PR DESCRIPTION
## Description

This pull request adds short command aliases for common Atlas commands to improve user efficiency and workflow speed. Users can now use single-character shortcuts like `/a` for `/add`, `/c` for `/commit`, etc., reducing typing time during interactive sessions.

The implementation includes:
- A centralized `COMMAND_ALIASES` mapping in the `Commands` class
- Updated command discovery and matching logic to resolve aliases to their full commands
- Enhanced tab completion support for aliases
- Updated help output to display available aliases alongside their corresponding commands

Closes #69.

**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**

## Checklist if Applicable

- [x] The tests passed: – `uv run --extra dev pytest tests/basic/test_commands.py -v`
- [x] Linting passed – `uv run --extra dev ruff check cli/commands.py cli/io.py`
- [ ] Documentation has been added
- [ ] CHANGELOG.md has been updated