### PR TITLE
Add centered hero to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
-# Forall
+<div align="center">
 
-<a href="./LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square" /></a>
-<a href="https://discord.com/invite/gESuZkdD5R"><img alt="Discord" src="https://img.shields.io/badge/Discord-community-5865F2?style=flat-square&logo=discord&logoColor=white" /></a>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/forall-dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="assets/forall-light.png" />
+  <img alt="Forall" src="assets/forall-light.png" width="180" />
+</picture>
 
+<h1>Forall</h1>
 
-Forall is a coding agent for spec-driven development and verification.
+<p>A coding agent for spec-driven development and verification.</p>
+
+<p>
+  <a href="./LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square" /></a>
+  <a href="https://discord.com/invite/gESuZkdD5R"><img alt="Discord" src="https://img.shields.io/badge/Discord-community-5865F2?style=flat-square&logo=discord&logoColor=white" /></a>
+</p>
+
+<img alt="Forall CLI" src="assets/forall-cli.jpg" width="800" />
+
+</div>
 
 This repository distributes the **Forall CLI** (prebuilt binaries), documentation, and community assets. The agent source is not published here.
 


### PR DESCRIPTION
## Summary
- Center logo (adaptive light/dark), tagline, badges, and CLI screenshot at the top of the README.

## Test plan
- [ ] Hero renders centered on GitHub in both color schemes

Made with [Cursor](https://cursor.com)