### PR TITLE
Point install command at forall.astrio.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/astrio-ai/forall/main/install.sh | bash
+curl -fsSL https://forall.astrio.app/install.sh | bash
 ```
 
 Add `~/.local/bin` to your `PATH` if needed, then run `forall --version`.


### PR DESCRIPTION
Serve the installer from the custom domain instead of raw.githubusercontent.com.

Made with [Cursor](https://cursor.com)