### PR TITLE
Add hosted MCP authoring skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,3 +1,42 @@
 # Skills
 
-Sample skills and plugins will be added here.
+Cursor / Claude Code / Codex skills for the **author locally → verify on hosted
+MCP** loop. These skills do **not** require the Forall CLI.
+
+| Skill | Purpose |
+|-------|---------|
+| [`forall-mcp-author`](./forall-mcp-author/SKILL.md) | Brownfield init, mapping, and proof-contract scaffolding (TS / Java / Rust) |
+| [`forall-mcp-verify`](./forall-mcp-verify/SKILL.md) | Hosted `forall_verify` → status → explain playbook |
+
+Shared references:
+
+- [`references/layout.md`](./references/layout.md) — `.forall/` bootstrap
+- [`references/mapping.md`](./references/mapping.md) — mapping schema + examples
+- [`references/lemmascript.md`](./references/lemmascript.md) — TypeScript contracts
+- [`references/verus.md`](./references/verus.md) — Rust / Verus contracts
+- [`references/openjml.md`](./references/openjml.md) — Java / OpenJML contracts
+
+## Install (Cursor)
+
+Copy into your project or user skills directory:
+
+```bash
+mkdir -p .cursor/skills
+cp -R skills/forall-mcp-author skills/forall-mcp-verify .cursor/skills/
+cp -R skills/references .cursor/skills/references
+```
+
+Or point the agent at this repo’s `skills/` folder.
+
+## Prerequisites
+
+1. Configure the hosted MCP endpoint described in
+   [`forall-mcp-verify`](./forall-mcp-verify/SKILL.md)
+2. Set `FORALL_API_KEY` for the MCP client
+3. Open a TypeScript, Java, or Rust workspace
+
+## Typical loop
+
+1. Run **forall-mcp-author** to create `.forall/` + map 1–5 symbols + add contracts
+2. Run **forall-mcp-verify** to submit hosted verification
+3. Fix CRITICAL issues locally and re-verify

--- a/skills/forall-mcp-author/SKILL.md
+++ b/skills/forall-mcp-author/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: forall-mcp-author
+description: >-
+  Author Forall verification artifacts for brownfield TypeScript, Java, or Rust
+  projects without the Forall CLI. Creates .forall layout, mapping, adapters,
+  and proof contracts, then hands off to hosted MCP verify. Use when the user
+  wants Cursor/Claude/Codex to add machine-checked specs and call hosted
+  forall_verify.
+license: MIT
+compatibility: >-
+  Requires write access to the project workspace. Hosted MCP
+  (forall_verify / forall_verification_status / forall_explain_verification)
+  for verification — Forall CLI is optional.
+metadata:
+  author: forall
+  version: "1.0"
+---
+
+# Forall MCP author (brownfield → hosted verify)
+
+Turn an existing TypeScript, Java, or Rust codebase into a Forall-verified
+project by **writing files locally**, then verifying with **hosted MCP**.
+
+Do **not** wait for Forall CLI. Do **not** ask the hosted worker to invent
+specs — it only checks what you commit to the workspace (or upload inline).
+
+## When to use
+
+- User asks to verify, prove, or Forall-ify a brownfield repo
+- Empty or skeleton `.forall/` exists but nothing is mapped
+- User wants Cursor / Claude Code / Codex + hosted MCP (no local provers)
+
+## Architecture
+
+```text
+This skill (local file writes)
+  init → discover → map → scaffold contracts → (optional PBT)
+        ↓
+forall-mcp-verify skill / hosted MCP tools
+  forall_verify → status → explain → fix → re-verify
+```
+
+## Languages
+
+| Language | Proof contracts | Adapter `proof` |
+|----------|-----------------|-----------------|
+| TypeScript / TSX | `//@ requires` / `//@ ensures` / `//@ contract` (+ companion `.dfy` when needed) | `lemmascript-dafny` |
+| Rust | inline Verus `requires` / `ensures` / `proof` | `verus` |
+| Java | JML `//@ requires` / `//@ ensures` above methods | `openjml` |
+
+Read language details from:
+
+- `skills/references/lemmascript.md`
+- `skills/references/verus.md`
+- `skills/references/openjml.md`
+- `skills/references/mapping.md`
+- `skills/references/layout.md`
+
+## Steps
+
+### 1. Detect project languages
+
+Inspect the workspace root:
+
+- TypeScript: `package.json`, `tsconfig.json`, `src/**/*.{ts,tsx}`
+- Rust: `Cargo.toml`, `src/**/*.rs`
+- Java: `pom.xml` / `build.gradle*`, `src/**/*.java`
+
+Prefer **pure logic** modules (math, validation, parsing, scoring). Leave UI,
+HTTP glue, and I/O **spec-tracked** (`verified: false`) on the first pass.
+
+### 2. Ensure `.forall/` layout
+
+If `.forall/verify/mapping.yaml` is missing, create the layout from
+`skills/references/layout.md`:
+
+```text
+.forall/
+  AGENTS.md
+  verify/
+    mapping.yaml
+    adapters.yaml
+  workflow/
+    config.yaml
+  scenarios/          # optional property tests
+  specs/              # optional markdown specs
+```
+
+Rules:
+
+- Never overwrite a non-empty `mapping.yaml` — merge requirements instead
+- Always write `adapters.yaml` with defaults for detected languages
+- Keep `version: 1` on mapping files
+
+### 3. Discover candidates (brownfield)
+
+Pick a small first slice (1–5 symbols), not the whole tree.
+
+**Heuristics (no CLI required):**
+
+1. Exported / public functions with clear pre/postconditions
+2. Already-annotated symbols (`//@`, Verus `requires`, JML)
+3. Pure functions (no network, filesystem, or DOM)
+
+For each candidate, record:
+
+- `id` (kebab-case, stable)
+- `capability` (short group name)
+- `requirement` (one sentence SHALL)
+- `code.file` + `code.symbols`
+- Tier: `verified: true` (default for finite logic) or `verified: false` (spec-tracked) or `property_tested: true` (quantified / infinite domains)
+
+Show the proposed slice to the user if scope is ambiguous; otherwise proceed
+with a minimal high-value set.
+
+### 4. Write / update mapping
+
+Edit `.forall/verify/mapping.yaml` (project-wide) or
+`.forall/workflow/changes/<name>/mapping.delta.yaml` (change-scoped).
+
+Minimal verified requirement:
+
+```yaml
+version: 1
+requirements:
+  - id: clamp-bounds
+    capability: math
+    requirement: clamp returns a value within [lo, hi] when lo <= hi
+    verified: true
+    code:
+      file: src/clamp.ts
+      symbols: [clamp]
+    contract: |
+      requires lo <= hi
+      ensures lo <= result <= hi
+```
+
+Copy full schema notes from `skills/references/mapping.md`.
+
+### 5. Scaffold proof contracts in source
+
+For each `verified: true` requirement:
+
+**TypeScript** — inside the function body (LemmaScript style):
+
+```ts
+export function clamp(x: number, lo: number, hi: number): number {
+  //@ requires lo <= hi
+  //@ ensures lo <= $result && $result <= hi
+  if (x < lo) return lo;
+  if (x > hi) return hi;
+  return x;
+}
+```
+
+If proofs need lemmas, add a sibling `src/clamp.dfy` (see
+`skills/references/lemmascript.md`). Prefer simple contracts first; let hosted
+check reveal what’s missing.
+
+**Rust** — Verus specs on the function:
+
+```rust
+pub fn clamp(x: u64, lo: u64, hi: u64) -> (result: u64)
+    requires lo <= hi,
+    ensures lo <= result && result <= hi,
+{
+    if x < lo { lo } else if x > hi { hi } else { x }
+}
+```
+
+Ensure `Cargo.toml` has `[package.metadata.verus] verify = true` when verifying
+Rust crates.
+
+**Java** — JML above the method:
+
+```java
+//@ requires lo <= hi;
+//@ ensures lo <= \result && \result <= hi;
+public static int clamp(int x, int lo, int hi) { ... }
+```
+
+Prove **scalar** methods first. Keep array/`\sum`/recursive aggregates
+spec-tracked until core lemmas pass.
+
+### 6. Optional property tests
+
+Only when the user asks for PBT, or the property is inherently quantified:
+
+- Add `.forall/scenarios/<id>.property.ts`
+- Set `property_tested: true` and `property: { file, symbol }` on the requirement
+- Do **not** replace finite deterministic logic with PBT
+
+### 7. Hand off to hosted verify
+
+Load `skills/forall-mcp-verify/SKILL.md` and run the verify loop.
+
+Prefer:
+
+1. **GitHub source** if the branch is pushed and public
+2. **Inline source** otherwise — upload `.forall/**`, mapped sources, adapters,
+   companion `.dfy` / Cargo / Java files needed for the check
+
+### 8. Fix and iterate
+
+On CRITICAL proof/mapping failures:
+
+1. Call `forall_explain_verification` for opaque issues
+2. Fix contracts or implementation locally
+3. Re-submit verify
+4. Never set `verified: false` only to silence a toolchain or proof failure
+5. Never use `//@ assume` / unproven `assume()` to cheat
+
+## Guardrails
+
+- Authoring = **local writes**; hosted MCP = **remote check only**
+- Start with 1–5 requirements; expand after the first green proofs phase
+- User-facing status: say **Forall verified** / **machine-checked** — do not
+  name LemmaScript, Dafny, Verus, or OpenJML unless debugging toolchain output
+- Keep UI / presentation / HTTP orchestration spec-tracked
+- Do not invent private repo access — hosted GitHub source is public-only today

--- a/skills/forall-mcp-verify/SKILL.md
+++ b/skills/forall-mcp-verify/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: forall-mcp-verify
+description: >-
+  Run hosted Forall verification via MCP (forall_verify, status, cancel,
+  explain) without the Forall CLI. Use after authoring .forall mapping and
+  proof contracts, or whenever the user asks to check / re-verify a project
+  with the hosted Forall MCP server.
+license: MIT
+compatibility: >-
+  Requires the Forall hosted MCP server configured with FORALL_API_KEY.
+  Forall CLI is not required.
+metadata:
+  author: forall
+  version: "1.0"
+---
+
+# Forall MCP verify (hosted check)
+
+Submit verification to the hosted Forall MCP service and iterate on the report.
+
+Endpoint: `https://mcp.forall.astrio.app/mcp`
+Auth: `Authorization: Bearer <FORALL_API_KEY>`
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `forall_verify` | Submit async job (inline files or public GitHub) |
+| `forall_verification_status` | Poll progress + sanitized report |
+| `forall_cancel_verification` | Cancel queued/running job |
+| `forall_explain_verification` | Explain selected findings |
+
+## Preconditions
+
+Before verify:
+
+1. `.forall/verify/mapping.yaml` exists (`version: 1`)
+2. At least one requirement is mapped, or you accept a structure-only pass
+3. `verified: true` requirements have contracts in source (see
+   `skills/forall-mcp-author/SKILL.md` and `skills/references/`)
+4. `.forall/verify/adapters.yaml` covers the languages you map
+
+If mapping is empty, hosted check may succeed with structure warnings only —
+that is **not** useful verification. Author requirements first.
+
+## Steps
+
+### 1. Choose source
+
+**GitHub** (preferred when the commit is public and pushed):
+
+```json
+{
+  "source": {
+    "type": "github",
+    "repository": "owner/repo",
+    "ref": "main"
+  },
+  "scope": { "type": "project" },
+  "strict": false
+}
+```
+
+Optional: `subdirectory` for monorepos.
+
+**Inline** (local / private / unpushed work):
+
+Include every path the check needs:
+
+- `.forall/verify/mapping.yaml`
+- `.forall/verify/adapters.yaml`
+- mapped source files (`.ts` / `.tsx` / `.rs` / `.java`)
+- companion `.dfy` files for TypeScript proofs when present
+- `Cargo.toml` (+ crate sources) for Rust
+- property-test files under `.forall/scenarios/` when `property_tested: true`
+
+```json
+{
+  "source": {
+    "type": "inline",
+    "files": [
+      { "path": ".forall/verify/mapping.yaml", "content": "..." },
+      { "path": ".forall/verify/adapters.yaml", "content": "..." },
+      { "path": "src/clamp.ts", "content": "..." }
+    ]
+  },
+  "scope": { "type": "project" },
+  "strict": false
+}
+```
+
+Change-scoped check:
+
+```json
+{
+  "scope": { "type": "change", "name": "add-clamp-bounds" }
+}
+```
+
+### 2. Submit
+
+Call `forall_verify`. Save `job_id` and honor `poll_after_ms`.
+
+### 3. Poll until terminal
+
+Call `forall_verification_status` with `{ "job_id": "vrf_..." }`.
+
+Terminal states: `succeeded`, `failed`, `cancelled`, `expired`.
+
+Non-terminal: `queued`, `preparing`, `running` — wait and poll again.
+
+### 4. Read the report
+
+Focus on:
+
+- `result.ok`
+- `result.phases` (`structure`, `mapping`, `proofs`, …)
+- `result.issues[]` with `severity`, `phase`, `file`, `requirement_id`,
+  `message`, `proof_detail`, `counterexample`
+- `result.verification_summary` (proved / property-tested / spec-tracked counts)
+
+CRITICAL issues block a real verify claim. Fix them before telling the user
+the project is machine-checked.
+
+### 5. Explain opaque failures
+
+```json
+{
+  "job_id": "vrf_...",
+  "issue_indexes": [0, 1],
+  "audience": "developer"
+}
+```
+
+Use explanations to drive local edits, then re-submit.
+
+### 6. Report to the user
+
+```text
+## Forall verification
+
+- Job: vrf_...
+- Status: succeeded | failed
+- Summary: N proved / M property-tested / K spec-tracked
+
+### CRITICAL
+- ...
+
+### WARNING
+- ...
+
+### Next
+- Fix X in file Y, then re-run hosted verify
+```
+
+User-facing language: **Forall verified** / **machine-checked**. Do not name
+internal provers unless the user is debugging toolchain output.
+
+## Guardrails
+
+- Never claim success from an empty mapping / structure-only pass
+- Never downgrade `verified: true` to silence failures
+- Prefer GitHub source when the revision is already public
+- Keep API keys out of the repo and chat logs
+- Cancel long jobs with `forall_cancel_verification` if the user aborts

--- a/skills/references/layout.md
+++ b/skills/references/layout.md
@@ -1,0 +1,91 @@
+# `.forall` layout (hosted MCP authoring)
+
+Create this layout when bootstrapping a brownfield project for hosted verify.
+Paths are relative to the project root.
+
+```text
+.forall/
+  AGENTS.md
+  verify/
+    mapping.yaml      # required marker
+    adapters.yaml     # proof routing by language
+  workflow/
+    config.yaml
+  scenarios/          # optional *.property.ts
+  specs/              # optional markdown specs
+```
+
+## `.forall/verify/mapping.yaml`
+
+```yaml
+version: 1
+requirements: []
+```
+
+Replace `requirements` when mapping symbols (see `mapping.md`).
+
+## `.forall/verify/adapters.yaml`
+
+```yaml
+backend: dafny
+strict: false
+adapters:
+  typescript:
+    proof: lemmascript-dafny
+    extensions: [ts, tsx]
+  rust:
+    proof: verus
+    extensions: [rs]
+  java:
+    proof: openjml
+    extensions: [java]
+  python:
+    proof: none
+    extensions: [py]
+```
+
+Omit unused language adapters if you prefer a minimal file; hosted check merges
+known defaults. Prefer writing the languages you actually map.
+
+## `.forall/workflow/config.yaml`
+
+```yaml
+schema: forall
+context: |
+  This project uses Forall verification with hosted MCP.
+  Author mapping and contracts locally; verify with forall_verify.
+rules:
+  verification:
+    - Keep verified: true requirements machine-checked before claiming success
+    - Prefer hosted forall_verify over skipping formal checks
+```
+
+## `.forall/AGENTS.md`
+
+Short agent reminder (safe to customize):
+
+```markdown
+# Forall
+
+Author `.forall/verify/mapping.yaml` and proof contracts in source.
+Verify with hosted MCP (`forall_verify` → status → explain).
+Say "Forall verified" / "machine-checked" in user-facing reports.
+```
+
+## Optional change workflow
+
+If you want change-scoped checks without the CLI:
+
+```text
+.forall/workflow/changes/<kebab-name>/
+  mapping.delta.yaml
+  proposal.md          # optional
+```
+
+Hosted verify accepts `scope: { type: "change", name: "<kebab-name>" }`.
+
+## Do not
+
+- Leave mapping empty and call that “verified”
+- Put secrets under `.forall/`
+- Rely on the hosted worker to create these files in the user’s tree

--- a/skills/references/lemmascript.md
+++ b/skills/references/lemmascript.md
@@ -1,0 +1,72 @@
+# TypeScript / LemmaScript contracts
+
+Adapter: `typescript` → `proof: lemmascript-dafny`
+Extensions: `.ts`, `.tsx`
+
+Hosted check runs LemmaScript extract + Dafny proofs on mapped files.
+Contracts live in TypeScript as `//@` annotations. Companion `.dfy` files sit
+next to the source when lemmas or manual proof edits are needed.
+
+## Annotation style
+
+Place annotations **inside** the function (LemmaScript extract style):
+
+```ts
+export function clamp(x: number, lo: number, hi: number): number {
+  //@ requires lo <= hi
+  //@ ensures lo <= $result && $result <= hi
+  //@ contract Bounds clamp
+  if (x < lo) return lo;
+  if (x > hi) return hi;
+  return x;
+}
+```
+
+Notes:
+
+- Use `$result` for the return value in ensures
+- Keep predicates decidable and local to the function
+- Avoid I/O, DOM, and network inside verified functions
+
+## Mapping
+
+```yaml
+verified: true
+code:
+  file: src/clamp.ts
+  symbols: [clamp]
+```
+
+## Companion Dafny files
+
+For `src/clamp.ts`, LemmaScript may use:
+
+- `src/clamp.dfy` — editable proof surface
+- generated merge artifacts (`.dfy.gen`, `.dfy.base`, `.dfy.merged`)
+
+Authoring guidance:
+
+1. Start with `//@` only and run hosted verify
+2. If proofs fail needing lemmas, add/edit `src/clamp.dfy`
+3. Never leave git conflict markers in `.dfy` / `.dfy.merged`
+4. When uploading inline to MCP, include both `.ts` and any `.dfy` siblings
+
+## Good first targets
+
+- Bounds clamping, saturation arithmetic
+- Parsers with finite grammars
+- Validators / policy checks with clear preconditions
+- Pure scoring / ranking helpers
+
+## Avoid on first pass
+
+- React components and hooks
+- Fetch / filesystem wrappers
+- Functions whose specs need unbounded quantification (use PBT or split)
+
+## Failure loop
+
+1. Read `proofs` phase issues from hosted status
+2. Tighten `//@ requires` / `//@ ensures` or fix the implementation
+3. Add lemmas in `.dfy` only when the contract is already honest
+4. Re-verify — do not flip `verified: false` to silence failures

--- a/skills/references/mapping.md
+++ b/skills/references/mapping.md
@@ -1,0 +1,123 @@
+# Mapping schema reference
+
+File: `.forall/verify/mapping.yaml` (project) or
+`.forall/workflow/changes/<name>/mapping.delta.yaml` (change).
+
+## Top level
+
+```yaml
+version: 1
+requirements:
+  - id: ...
+```
+
+`version` must be `1`.
+
+## Requirement fields
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `id` | yes | Stable kebab-case id |
+| `capability` | yes | Grouping label |
+| `requirement` | yes | One-sentence SHALL |
+| `verified` | no (default false) | Formal proof required |
+| `property_tested` | no | Property-test required |
+| `code.file` | for verify/PBT | Repo-relative source path |
+| `code.symbols` | for verify/PBT | Function / method names |
+| `contract` | recommended | Human-readable pre/post sketch |
+| `property.file` | when PBT | Path to `*.property.ts` |
+| `property.symbol` | optional | Export name inside the PBT file |
+| `scenarios` | optional | Named scenario refs |
+| `claimcheck` | optional | Claimcheck linkage |
+
+## Tiers
+
+1. **Proved** — `verified: true` + contracts in source + proofs phase pass
+2. **Property-tested** — `property_tested: true` + scenario file pass
+3. **Spec-tracked** — mapped only (`verified: false`, no PBT)
+
+Default for finite deterministic logic: **proved**.
+
+## Examples
+
+### TypeScript (proved)
+
+```yaml
+version: 1
+requirements:
+  - id: clamp-bounds
+    capability: math
+    requirement: clamp returns a value within [lo, hi] when lo <= hi
+    verified: true
+    code:
+      file: src/clamp.ts
+      symbols: [clamp]
+    contract: |
+      requires lo <= hi
+      ensures lo <= result <= hi
+```
+
+### Rust (proved)
+
+```yaml
+  - id: clamp-bounds
+    capability: math
+    requirement: clamp returns a value within [lo, hi] when lo <= hi
+    verified: true
+    code:
+      file: src/clamp.rs
+      symbols: [clamp]
+    contract: |
+      requires lo <= hi
+      ensures lo <= result <= hi
+```
+
+### Java (proved)
+
+```yaml
+  - id: clamp-bounds
+    capability: math
+    requirement: clamp returns a value within [lo, hi] when lo <= hi
+    verified: true
+    code:
+      file: src/Clamp.java
+      symbols: [clamp]
+    contract: |
+      requires lo <= hi
+      ensures lo <= result <= hi
+```
+
+### Spec-tracked (UI / glue)
+
+```yaml
+  - id: render-settings-panel
+    capability: ui
+    requirement: settings panel renders title and controls
+    verified: false
+    code:
+      file: src/SettingsPanel.tsx
+      symbols: [SettingsPanel]
+```
+
+### Property-tested
+
+```yaml
+  - id: parse-accepts-fuzz
+    capability: parse
+    requirement: parser never throws on arbitrary strings
+    property_tested: true
+    property:
+      file: .forall/scenarios/parse-accepts-fuzz.property.ts
+      symbol: parseAcceptsFuzz
+    code:
+      file: src/parse.ts
+      symbols: [parse]
+```
+
+## Discovery tips (no CLI)
+
+1. Prefer already-exported pure functions
+2. Prefer symbols with existing annotations
+3. Start with 1–5 requirements
+4. Keep HTTP handlers / array orchestration / presentation spec-tracked first
+5. Merge into existing mapping — do not wipe unrelated ids

--- a/skills/references/openjml.md
+++ b/skills/references/openjml.md
@@ -1,0 +1,62 @@
+# Java / OpenJML contracts
+
+Adapter: `java` → `proof: openjml`
+Extensions: `.java`
+
+Specs are JML line comments **above** methods. No sync step.
+
+## Annotation style
+
+```java
+public class Clamp {
+    //@ requires lo <= hi;
+    //@ ensures lo <= \result && \result <= hi;
+    public static int clamp(int x, int lo, int hi) {
+        if (x < lo) return lo;
+        if (x > hi) return hi;
+        return x;
+    }
+}
+```
+
+Notes:
+
+- Use `\result` for the return value
+- Terminate JML clauses with `;`
+- Prefer `public static` pure helpers for the first proved slice
+
+## Mapping
+
+```yaml
+verified: true
+code:
+  file: src/Clamp.java
+  symbols: [clamp]
+```
+
+## Proof scope (important)
+
+OpenJML ESC is strongest on **scalar** methods. First pass:
+
+- Prove one method at a time (`clamp`, `shareFor`, …)
+- Keep array assembly, HTTP handlers, and multi-method orchestration
+  **spec-tracked** (`verified: false`)
+
+Avoid until core lemmas pass:
+
+- JML `\sum` over arrays
+- Recursive prefix-sum style postconditions
+- Heavy loop invariants tying multiple arrays together
+
+## Good first targets
+
+- Bounds / saturation
+- Fee or share calculations on scalars
+- Predicate helpers with explicit requires
+
+## Failure loop
+
+1. Read hosted `proofs` issues / `proof_detail`
+2. Simplify ensures; split methods if needed
+3. Keep hard array logic spec-tracked temporarily
+4. Never flip `verified: true` → false only to silence ESC failures on core logic

--- a/skills/references/verus.md
+++ b/skills/references/verus.md
@@ -1,0 +1,81 @@
+# Rust / Verus contracts
+
+Adapter: `rust` → `proof: verus`
+Extensions: `.rs`
+
+Specs live **inline** in Rust. There is no separate sync / `.dfy` step.
+
+## Annotation style
+
+Prefer named results so ensures clauses can mention `result`:
+
+```rust
+pub fn clamp(x: u64, lo: u64, hi: u64) -> (result: u64)
+    requires
+        lo <= hi,
+    ensures
+        lo <= result && result <= hi,
+{
+    if x < lo {
+        lo
+    } else if x > hi {
+        hi
+    } else {
+        x
+    }
+}
+```
+
+Shorter form also works for simple cases:
+
+```rust
+pub fn clamp(x: u64, lo: u64, hi: u64) -> u64
+    requires lo <= hi,
+    ensures lo <= result && result <= hi,
+{
+    if x < lo { lo } else if x > hi { hi } else { x }
+}
+```
+
+Add `proof { ... }` blocks only when needed for non-trivial reasoning.
+
+## Cargo metadata
+
+Verified crates should include:
+
+```toml
+[package.metadata.verus]
+verify = true
+```
+
+When submitting inline files to hosted MCP, include `Cargo.toml` and the mapped
+crate sources.
+
+## Mapping
+
+```yaml
+verified: true
+code:
+  file: src/clamp.rs
+  symbols: [clamp]
+```
+
+## Good first targets
+
+- Pure numeric helpers
+- Invariants on IDs, ranges, and enums
+- Small state-transition functions with explicit preconditions
+
+## Avoid on first pass
+
+- `async` / Tokio glue
+- FFI and `unsafe` without a narrow verified core
+- Large modules — extract a pure helper and map that instead
+
+## Failure loop
+
+1. Fix `requires` / `ensures` or the body
+2. Keep proofs honest — no unproven `assume`
+3. Re-run hosted `forall_verify`
+4. Do not downgrade `verified: true` because proofs are hard; simplify the
+   contract or shrink the verified surface


### PR DESCRIPTION
## Summary
- add a local authoring skill for brownfield TypeScript, Rust, and Java projects
- add a hosted MCP verification playbook for submit, poll, explain, and iterate
- add reusable layout, mapping, and language contract references

## Test plan
- [x] Verify the branch diff contains only `skills/**`
- [x] Run `git diff --check` on the skills patch
- [ ] Exercise the skills in a sample brownfield repository

Made with [Cursor](https://cursor.com)