### PR TITLE
Remove verification implementation details from public skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -12,9 +12,9 @@ Shared references:
 
 - [`references/layout.md`](./references/layout.md) — `.forall/` bootstrap
 - [`references/mapping.md`](./references/mapping.md) — mapping schema + examples
-- [`references/lemmascript.md`](./references/lemmascript.md) — TypeScript contracts
-- [`references/verus.md`](./references/verus.md) — Rust / Verus contracts
-- [`references/openjml.md`](./references/openjml.md) — Java / OpenJML contracts
+- [`references/typescript.md`](./references/typescript.md) — TypeScript contracts
+- [`references/rust.md`](./references/rust.md) — Rust contracts
+- [`references/java.md`](./references/java.md) — Java contracts
 
 ## Install (Cursor)
 

--- a/skills/forall-mcp-author/SKILL.md
+++ b/skills/forall-mcp-author/SKILL.md
@@ -2,7 +2,7 @@
 name: forall-mcp-author
 description: >-
   Author Forall verification artifacts for brownfield TypeScript, Java, or Rust
-  projects without the Forall CLI. Creates .forall layout, mapping, adapters,
+  projects without the Forall CLI. Creates .forall layout, mapping,
   and proof contracts, then hands off to hosted MCP verify. Use when the user
   wants Cursor/Claude/Codex to add machine-checked specs and call hosted
   forall_verify.
@@ -28,7 +28,7 @@ specs — it only checks what you commit to the workspace (or upload inline).
 
 - User asks to verify, prove, or Forall-ify a brownfield repo
 - Empty or skeleton `.forall/` exists but nothing is mapped
-- User wants Cursor / Claude Code / Codex + hosted MCP (no local provers)
+- User wants Cursor / Claude Code / Codex + hosted MCP
 
 ## Architecture
 
@@ -42,17 +42,17 @@ forall-mcp-verify skill / hosted MCP tools
 
 ## Languages
 
-| Language | Proof contracts | Adapter `proof` |
-|----------|-----------------|-----------------|
-| TypeScript / TSX | `//@ requires` / `//@ ensures` / `//@ contract` (+ companion `.dfy` when needed) | `lemmascript-dafny` |
-| Rust | inline Verus `requires` / `ensures` / `proof` | `verus` |
-| Java | JML `//@ requires` / `//@ ensures` above methods | `openjml` |
+| Language | Forall contract syntax |
+|----------|------------------------|
+| TypeScript / TSX | `//@ requires` / `//@ ensures` / `//@ contract` |
+| Rust | inline `requires` / `ensures` / `proof` |
+| Java | `//@ requires` / `//@ ensures` above methods |
 
 Read language details from:
 
-- `skills/references/lemmascript.md`
-- `skills/references/verus.md`
-- `skills/references/openjml.md`
+- `skills/references/typescript.md`
+- `skills/references/rust.md`
+- `skills/references/java.md`
 - `skills/references/mapping.md`
 - `skills/references/layout.md`
 
@@ -79,7 +79,6 @@ If `.forall/verify/mapping.yaml` is missing, create the layout from
   AGENTS.md
   verify/
     mapping.yaml
-    adapters.yaml
   workflow/
     config.yaml
   scenarios/          # optional property tests
@@ -89,7 +88,6 @@ If `.forall/verify/mapping.yaml` is missing, create the layout from
 Rules:
 
 - Never overwrite a non-empty `mapping.yaml` — merge requirements instead
-- Always write `adapters.yaml` with defaults for detected languages
 - Keep `version: 1` on mapping files
 
 ### 3. Discover candidates (brownfield)
@@ -99,7 +97,7 @@ Pick a small first slice (1–5 symbols), not the whole tree.
 **Heuristics (no CLI required):**
 
 1. Exported / public functions with clear pre/postconditions
-2. Already-annotated symbols (`//@`, Verus `requires`, JML)
+2. Already-annotated symbols (`//@`, `requires`, `ensures`)
 3. Pure functions (no network, filesystem, or DOM)
 
 For each candidate, record:
@@ -141,7 +139,7 @@ Copy full schema notes from `skills/references/mapping.md`.
 
 For each `verified: true` requirement:
 
-**TypeScript** — inside the function body (LemmaScript style):
+**TypeScript** — inside the function body:
 
 ```ts
 export function clamp(x: number, lo: number, hi: number): number {
@@ -153,11 +151,9 @@ export function clamp(x: number, lo: number, hi: number): number {
 }
 ```
 
-If proofs need lemmas, add a sibling `src/clamp.dfy` (see
-`skills/references/lemmascript.md`). Prefer simple contracts first; let hosted
-check reveal what’s missing.
+Prefer simple contracts first; let hosted check reveal what is missing.
 
-**Rust** — Verus specs on the function:
+**Rust** — Forall contracts on the function:
 
 ```rust
 pub fn clamp(x: u64, lo: u64, hi: u64) -> (result: u64)
@@ -168,10 +164,7 @@ pub fn clamp(x: u64, lo: u64, hi: u64) -> (result: u64)
 }
 ```
 
-Ensure `Cargo.toml` has `[package.metadata.verus] verify = true` when verifying
-Rust crates.
-
-**Java** — JML above the method:
+**Java** — Forall contracts above the method:
 
 ```java
 //@ requires lo <= hi;
@@ -197,8 +190,8 @@ Load `skills/forall-mcp-verify/SKILL.md` and run the verify loop.
 Prefer:
 
 1. **GitHub source** if the branch is pushed and public
-2. **Inline source** otherwise — upload `.forall/**`, mapped sources, adapters,
-   companion `.dfy` / Cargo / Java files needed for the check
+2. **Inline source** otherwise — upload `.forall/**`, mapped sources, and
+   supporting project files needed for the check
 
 ### 8. Fix and iterate
 
@@ -207,14 +200,13 @@ On CRITICAL proof/mapping failures:
 1. Call `forall_explain_verification` for opaque issues
 2. Fix contracts or implementation locally
 3. Re-submit verify
-4. Never set `verified: false` only to silence a toolchain or proof failure
+4. Never set `verified: false` only to silence a verification failure
 5. Never use `//@ assume` / unproven `assume()` to cheat
 
 ## Guardrails
 
 - Authoring = **local writes**; hosted MCP = **remote check only**
 - Start with 1–5 requirements; expand after the first green proofs phase
-- User-facing status: say **Forall verified** / **machine-checked** — do not
-  name LemmaScript, Dafny, Verus, or OpenJML unless debugging toolchain output
+- User-facing status: say **Forall verified** / **machine-checked**
 - Keep UI / presentation / HTTP orchestration spec-tracked
 - Do not invent private repo access — hosted GitHub source is public-only today

--- a/skills/forall-mcp-verify/SKILL.md
+++ b/skills/forall-mcp-verify/SKILL.md
@@ -38,7 +38,6 @@ Before verify:
 2. At least one requirement is mapped, or you accept a structure-only pass
 3. `verified: true` requirements have contracts in source (see
    `skills/forall-mcp-author/SKILL.md` and `skills/references/`)
-4. `.forall/verify/adapters.yaml` covers the languages you map
 
 If mapping is empty, hosted check may succeed with structure warnings only —
 that is **not** useful verification. Author requirements first.
@@ -68,9 +67,7 @@ Optional: `subdirectory` for monorepos.
 Include every path the check needs:
 
 - `.forall/verify/mapping.yaml`
-- `.forall/verify/adapters.yaml`
 - mapped source files (`.ts` / `.tsx` / `.rs` / `.java`)
-- companion `.dfy` files for TypeScript proofs when present
 - `Cargo.toml` (+ crate sources) for Rust
 - property-test files under `.forall/scenarios/` when `property_tested: true`
 
@@ -80,7 +77,6 @@ Include every path the check needs:
     "type": "inline",
     "files": [
       { "path": ".forall/verify/mapping.yaml", "content": "..." },
-      { "path": ".forall/verify/adapters.yaml", "content": "..." },
       { "path": "src/clamp.ts", "content": "..." }
     ]
   },
@@ -153,8 +149,7 @@ Use explanations to drive local edits, then re-submit.
 - Fix X in file Y, then re-run hosted verify
 ```
 
-User-facing language: **Forall verified** / **machine-checked**. Do not name
-internal provers unless the user is debugging toolchain output.
+User-facing language: **Forall verified** / **machine-checked**.
 
 ## Guardrails
 

--- a/skills/references/java.md
+++ b/skills/references/java.md
@@ -1,9 +1,6 @@
-# Java / OpenJML contracts
+# Java contracts
 
-Adapter: `java` → `proof: openjml`
-Extensions: `.java`
-
-Specs are JML line comments **above** methods. No sync step.
+Forall contracts are `//@` line comments **above** methods.
 
 ## Annotation style
 
@@ -22,7 +19,7 @@ public class Clamp {
 Notes:
 
 - Use `\result` for the return value
-- Terminate JML clauses with `;`
+- Terminate contract clauses with `;`
 - Prefer `public static` pure helpers for the first proved slice
 
 ## Mapping
@@ -36,7 +33,7 @@ code:
 
 ## Proof scope (important)
 
-OpenJML ESC is strongest on **scalar** methods. First pass:
+Start with **scalar** methods:
 
 - Prove one method at a time (`clamp`, `shareFor`, …)
 - Keep array assembly, HTTP handlers, and multi-method orchestration
@@ -44,7 +41,7 @@ OpenJML ESC is strongest on **scalar** methods. First pass:
 
 Avoid until core lemmas pass:
 
-- JML `\sum` over arrays
+- Aggregate expressions over arrays
 - Recursive prefix-sum style postconditions
 - Heavy loop invariants tying multiple arrays together
 
@@ -59,4 +56,4 @@ Avoid until core lemmas pass:
 1. Read hosted `proofs` issues / `proof_detail`
 2. Simplify ensures; split methods if needed
 3. Keep hard array logic spec-tracked temporarily
-4. Never flip `verified: true` → false only to silence ESC failures on core logic
+4. Never flip `verified: true` → false only to silence failures on core logic

--- a/skills/references/layout.md
+++ b/skills/references/layout.md
@@ -8,7 +8,6 @@ Paths are relative to the project root.
   AGENTS.md
   verify/
     mapping.yaml      # required marker
-    adapters.yaml     # proof routing by language
   workflow/
     config.yaml
   scenarios/          # optional *.property.ts
@@ -23,29 +22,6 @@ requirements: []
 ```
 
 Replace `requirements` when mapping symbols (see `mapping.md`).
-
-## `.forall/verify/adapters.yaml`
-
-```yaml
-backend: dafny
-strict: false
-adapters:
-  typescript:
-    proof: lemmascript-dafny
-    extensions: [ts, tsx]
-  rust:
-    proof: verus
-    extensions: [rs]
-  java:
-    proof: openjml
-    extensions: [java]
-  python:
-    proof: none
-    extensions: [py]
-```
-
-Omit unused language adapters if you prefer a minimal file; hosted check merges
-known defaults. Prefer writing the languages you actually map.
 
 ## `.forall/workflow/config.yaml`
 

--- a/skills/references/rust.md
+++ b/skills/references/rust.md
@@ -1,9 +1,6 @@
-# Rust / Verus contracts
+# Rust contracts
 
-Adapter: `rust` → `proof: verus`
-Extensions: `.rs`
-
-Specs live **inline** in Rust. There is no separate sync / `.dfy` step.
+Forall contracts live inline in `.rs` files.
 
 ## Annotation style
 
@@ -38,15 +35,6 @@ pub fn clamp(x: u64, lo: u64, hi: u64) -> u64
 ```
 
 Add `proof { ... }` blocks only when needed for non-trivial reasoning.
-
-## Cargo metadata
-
-Verified crates should include:
-
-```toml
-[package.metadata.verus]
-verify = true
-```
 
 When submitting inline files to hosted MCP, include `Cargo.toml` and the mapped
 crate sources.

--- a/skills/references/typescript.md
+++ b/skills/references/typescript.md
@@ -1,15 +1,10 @@
-# TypeScript / LemmaScript contracts
+# TypeScript contracts
 
-Adapter: `typescript` → `proof: lemmascript-dafny`
-Extensions: `.ts`, `.tsx`
-
-Hosted check runs LemmaScript extract + Dafny proofs on mapped files.
-Contracts live in TypeScript as `//@` annotations. Companion `.dfy` files sit
-next to the source when lemmas or manual proof edits are needed.
+Forall contracts live in `.ts` and `.tsx` files as `//@` annotations.
 
 ## Annotation style
 
-Place annotations **inside** the function (LemmaScript extract style):
+Place annotations **inside** the function:
 
 ```ts
 export function clamp(x: number, lo: number, hi: number): number {
@@ -37,20 +32,6 @@ code:
   symbols: [clamp]
 ```
 
-## Companion Dafny files
-
-For `src/clamp.ts`, LemmaScript may use:
-
-- `src/clamp.dfy` — editable proof surface
-- generated merge artifacts (`.dfy.gen`, `.dfy.base`, `.dfy.merged`)
-
-Authoring guidance:
-
-1. Start with `//@` only and run hosted verify
-2. If proofs fail needing lemmas, add/edit `src/clamp.dfy`
-3. Never leave git conflict markers in `.dfy` / `.dfy.merged`
-4. When uploading inline to MCP, include both `.ts` and any `.dfy` siblings
-
 ## Good first targets
 
 - Bounds clamping, saturation arithmetic
@@ -68,5 +49,4 @@ Authoring guidance:
 
 1. Read `proofs` phase issues from hosted status
 2. Tighten `//@ requires` / `//@ ensures` or fix the implementation
-3. Add lemmas in `.dfy` only when the contract is already honest
-4. Re-verify — do not flip `verified: false` to silence failures
+3. Re-verify — do not flip `verified: false` to silence failures


### PR DESCRIPTION
## Summary
- remove verification backend names, adapter identifiers, and backend-specific artifacts from public skills
- rename language references to `typescript.md`, `rust.md`, and `java.md`
- keep public guidance limited to Forall contract syntax and hosted verification

## Test plan
- [x] Search all `skills/**` files for backend/tool terminology
- [x] Verify the PR diff contains only `skills/**`
- [x] Run `git diff --check`

Made with [Cursor](https://cursor.com)