### PR TITLE
Install from gzip-compressed release archives

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Forall installer — downloads prebuilt binaries from GitHub Releases.
+# Forall installer — downloads compressed prebuilt binaries from GitHub Releases.
 set -euo pipefail
 
 REPO="${FORALL_INSTALL_REPO:-astrio-ai/forall}"
@@ -9,7 +9,7 @@ BINARY_NAME="forall"
 info() { printf '%s\n' "$*"; }
 err() { printf 'forall install: %s\n' "$*" >&2; }
 
-detect_target() {
+detect_platform() {
   local os arch
   os="$(uname -s | tr '[:upper:]' '[:lower:]')"
   arch="$(uname -m)"
@@ -24,11 +24,7 @@ detect_target() {
     aarch64|arm64) arch="aarch64" ;;
     *) err "unsupported architecture: $arch"; exit 1 ;;
   esac
-  if [ "$os" = "windows" ]; then
-    printf '%s\n' "${BINARY_NAME}-${os}-${arch}.exe"
-  else
-    printf '%s\n' "${BINARY_NAME}-${os}-${arch}"
-  fi
+  printf '%s %s\n' "$os" "$arch"
 }
 
 latest_release_tag() {
@@ -40,10 +36,78 @@ latest_release_tag() {
     | head -n1
 }
 
+# Prefer an existing binary from PATH for extraction tools only when needed.
+have_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+download() {
+  local url="$1"
+  local out="$2"
+  curl -fsSL "$url" -o "$out"
+}
+
+install_from_archive() {
+  local url="$1"
+  local expected_name="$2"
+  local archive extract_dir binary
+  archive="$(mktemp)"
+  extract_dir="$(mktemp -d)"
+  cleanup() {
+    rm -f "$archive"
+    rm -rf "$extract_dir"
+  }
+  trap cleanup EXIT
+
+  if ! download "$url" "$archive"; then
+    trap - EXIT
+    cleanup
+    return 1
+  fi
+
+  if ! have_cmd tar; then
+    err "tar is required to unpack the Forall release archive"
+    trap - EXIT
+    cleanup
+    return 1
+  fi
+  tar -xzf "$archive" -C "$extract_dir"
+
+  binary="${extract_dir}/${expected_name}"
+  if [ ! -f "$binary" ]; then
+    # Tolerate archives that store just "forall" / "forall.exe".
+    if [ -f "${extract_dir}/${BINARY_NAME}" ]; then
+      binary="${extract_dir}/${BINARY_NAME}"
+    elif [ -f "${extract_dir}/${BINARY_NAME}.exe" ]; then
+      binary="${extract_dir}/${BINARY_NAME}.exe"
+    else
+      err "archive did not contain ${expected_name}"
+      trap - EXIT
+      cleanup
+      return 1
+    fi
+  fi
+
+  chmod +x "$binary"
+  mv "$binary" "${INSTALL_DIR}/${BINARY_NAME}"
+  trap - EXIT
+  cleanup
+}
+
+install_raw_binary() {
+  local url="$1"
+  local tmp
+  tmp="$(mktemp)"
+  if ! download "$url" "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  chmod +x "$tmp"
+  mv "$tmp" "${INSTALL_DIR}/${BINARY_NAME}"
+}
+
 main() {
-  local target tag asset url tmp
+  local os arch tag base url
   mkdir -p "$INSTALL_DIR"
-  target="$(detect_target)"
+  read -r os arch <<<"$(detect_platform)"
   tag="$(latest_release_tag || true)"
   if [ -z "${tag:-}" ]; then
     err "no release found at https://github.com/${REPO}/releases yet."
@@ -51,20 +115,30 @@ main() {
     exit 1
   fi
 
-  asset="${target}"
-  url="https://github.com/${REPO}/releases/download/${tag}/${asset}"
-  tmp="$(mktemp)"
-  info "Installing Forall ${tag} (${target}) to ${INSTALL_DIR}/${BINARY_NAME}"
-
-  if ! curl -fsSL "$url" -o "$tmp"; then
-    err "failed to download ${url}"
-    err "Expected release asset: ${asset}"
-    exit 1
+  if [ "$os" = "windows" ]; then
+    base="${BINARY_NAME}-${os}-${arch}.exe"
+  else
+    base="${BINARY_NAME}-${os}-${arch}"
   fi
 
-  chmod +x "$tmp"
-  mv "$tmp" "${INSTALL_DIR}/${BINARY_NAME}"
-  info "Installed ${INSTALL_DIR}/${BINARY_NAME}"
+  info "Installing Forall ${tag} (${base}) to ${INSTALL_DIR}/${BINARY_NAME}"
+
+  # Prefer compressed archives (new releases). Fall back to raw binaries
+  # so older release tags keep working.
+  url="https://github.com/${REPO}/releases/download/${tag}/${base}.tar.gz"
+  if install_from_archive "$url" "$base"; then
+    info "Installed ${INSTALL_DIR}/${BINARY_NAME}"
+  else
+    info "Compressed asset unavailable; trying raw binary…"
+    url="https://github.com/${REPO}/releases/download/${tag}/${base}"
+    if ! install_raw_binary "$url"; then
+      err "failed to download ${url}"
+      err "Expected release asset: ${base}.tar.gz or ${base}"
+      exit 1
+    fi
+    info "Installed ${INSTALL_DIR}/${BINARY_NAME}"
+  fi
+
   if ! command -v "$BINARY_NAME" >/dev/null 2>&1; then
     info "Add to PATH: export PATH=\"${INSTALL_DIR}:\$PATH\""
   fi


### PR DESCRIPTION
## Summary
- Download `forall-*.tar.gz` from GitHub Releases and extract with `tar`
- Fall back to raw binaries for pre-compression tags (e.g. v0.1.0)

Pairs with the forall-core release workflow change that publishes `.tar.gz` assets.

## Test plan
- [ ] `bash -n install.sh`
- [ ] After a compressed release exists: `FORALL_INSTALL_DIR=/tmp/forall-test bash install.sh`
- [ ] Against v0.1.0: confirm fallback to raw binary still works

Made with [Cursor](https://cursor.com)