### PR TITLE
Rewrite docs for two-path product model

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,19 @@
 # Forall Documentation
 
-User-facing documentation for the Forall CLI.
-
 | Guide | What it covers |
 |-------|----------------|
-| [Getting Started](getting-started.md) | Install Forall and set up your first project |
+| [Getting Started](getting-started.md) | Two paths: Forall CLI vs MCP verify-only |
 | [Project Layout](project-layout.md) | The `.forall/` directory and what each file does |
 | [Workflow](workflow.md) | The propose → verify → archive change workflow |
-| [Architecture](architecture.md) | Standalone binary, open-source adapters, and hosted verification |
-| [Local Authoring MCP](local-authoring-mcp.md) | Optional stdio MCP for external coding agents |
-| [Hosted Forall MCP](hosted-mcp.md) | Remote verification service and client library |
+| [Architecture](architecture.md) | Two-path product model and open-source components |
+| [Hosted Forall MCP](hosted-mcp.md) | Remote verification, dashboard keys, npm bridge |
+
+## Packages
+
+- [`packages/forall-mcp`](../packages/forall-mcp/README.md) — `@astrio/forall-mcp` npm bridge
 
 ## Open-source crates
 
-The [crates](../crates/) directory publishes the Rust libraries behind Forall's
-authoring and hosted verification adapters. The full agent runtime is still
-distributed as the prebuilt `forall` CLI; see [crates/README.md](../crates/README.md).
+The [crates](../crates/) directory publishes the Rust libraries embedded by the
+`forall` binary. The full agent runtime is distributed as the prebuilt CLI; see
+[crates/README.md](../crates/README.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,17 +1,22 @@
 # Architecture
 
-Forall is a standalone coding agent distributed as a single Rust binary
-(`forall`). Its primary user experience does not require Cursor or manual MCP
-configuration.
+Forall has two supported product paths. There is no Hybrid / local-authoring MCP
+path for external agents.
 
-This repository publishes the **open-source adapter crates** that the binary
-embeds. The full agent runtime (TUI, turn loop, sandbox, native tool
-registry) remains closed source and is distributed only as the `forall`
-executable.
+```text
+Path A — Forall CLI                         Path B — MCP verify-only
+───────────────────                         ────────────────────────
+install.sh → forall binary                  npm: @astrio/forall-mcp
+TUI: Forall account OR BYOK                 dashboard API key in MCP config
+native authoring + workflow in-process      stdio → hosted HTTP MCP
+optional hosted verify via Forall API key   verify tools only (no workspace writes)
+```
+
+See [getting-started.md](getting-started.md).
 
 ```text
 ┌────────────────────────────────────────────────────────────┐
-│  `forall` binary (closed-source distribution)              │
+│  Path A: `forall` binary (closed-source distribution)    │
 │  agent TUI · native tools · sandbox · workflow commands    │
 └────────────────────────────┬───────────────────────────────┘
                              │
@@ -19,7 +24,7 @@ executable.
 ┌────────────────────────────────────────────────────────────┐
 │  native author.*   deterministic workspace operations      │
 │  native verify.*   hosted submit / status / explain        │
-│  (call open-source libraries in-process)                   │
+│  (embed open-source crates in-process)                     │
 └───────────────┬───────────────────────────┬────────────────┘
                 │                           │
                 ▼                           ▼
@@ -27,145 +32,65 @@ executable.
 │ Project workspace            │  │ Hosted Forall MCP         │
 │ .forall/ + application code  │  │ isolated verification     │
 └──────────────────────────────┘  └───────────────────────────┘
+
+Path B: Cursor / Claude Code / Codex
+    npx @astrio/forall-mcp + FORALL_API_KEY
+         │
+         ▼
+    https://mcp.forall.astrio.app/mcp  →  same hosted workers
+    (host agent edits the repo from verify reports)
 ```
 
-The native `author.*` and hosted `verify.*` registrations implement the
-standalone architecture. They share the reusable authoring library and hosted
-wire client with the optional external adapters published in this repository.
+## Auth
 
-External coding agents use optional adapters around the same capabilities:
+| Audience | Credential | Where it is created / stored |
+|----------|------------|------------------------------|
+| CLI — Forall account | `FORALL_API_KEY` (`forall_…`) | [Dashboard](https://forall.astrio.app/dashboard) → paste in TUI or `forall verification login` |
+| CLI — BYOK | `OPENAI_API_KEY` / `OPENROUTER_API_KEY` | `~/.forall/.env` or `forall login --with-api-key` |
+| MCP verify-only | `FORALL_API_KEY` | Same dashboard → MCP client `env` |
 
-```text
-Cursor / Claude Code / Codex
-    ├─ local authoring MCP (stdio) ──► project workspace
-    └─ hosted Forall MCP (HTTP) ─────► isolated verification
-```
-
-Standalone Forall calls the authoring library directly. It must not spawn or
-connect to its own local MCP server.
-
-The two MCP servers are distinct:
-
-- [Local authoring MCP](local-authoring-mcp.md): optional workspace-bound stdio
-  adapter for external agents.
-- [Hosted Forall MCP](hosted-mcp.md): remote asynchronous verification service.
+Model chat always needs BYOK (or equivalent provider config). The Forall API key
+unlocks hosted verification and account-tied quotas.
 
 ## Open-source components
 
 | Component | Location | Role |
 | --- | --- | --- |
-| Authoring library | `crates/forall-authoring` | Safe status, initialization, discovery, mapping, contracts, and validation |
-| Hosted client | `crates/forall-hosted-verify` | Safe snapshot packaging and authenticated submit, status, cancellation, and explanation |
-| Local MCP adapter | `crates/forall-mcp-author` | Optional stdio authoring tools for external MCP clients |
+| Authoring library | `crates/forall-authoring` | Safe status, init, discovery, mapping, contracts, validation |
+| Hosted client | `crates/forall-hosted-verify` | Snapshot packaging and authenticated submit/status/cancel/explain |
+| npm MCP bridge | `packages/forall-mcp` | Stdio → hosted MCP for external agents (`@astrio/forall-mcp`) |
 
-See [crates/README.md](../crates/README.md) for crate-level details.
+The full agent runtime (TUI, turn loop, sandbox, native tool registry) is
+distributed only as the prebuilt `forall` binary.
 
-## Standalone tool surfaces
+## Hosted verification
 
-### Native `author.*` tools
+- **CLI users** call native `verify.*` tools (or `forall verification login`).
+  They should not manually add the hosted MCP URL to Forall.
+- **External agents** use `@astrio/forall-mcp` (or HTTP MCP with Bearer) only.
 
-Standalone Forall registers native authoring handlers that call
-`forall-authoring` in-process:
-
-- `author.status`
-- `author.init`
-- `author.discover`
-- `author.upsert_requirements`
-- `author.scaffold_contracts`
-- `author.validate`
-- `author.scaffold_property`
-
-Apply-mode tools retain preview, expected-hash, root-confinement, and atomic
-write guarantees. Application-code writes must participate in the agent's
-approval and VerifiedGate policies.
-
-### Native `verify.*` tools
-
-Standalone Forall exposes hosted verification without requiring users to
-configure MCP:
-
-- `verify.submit`
-- `verify.status`
-- `verify.cancel`
-- `verify.explain`
-
-The standalone client owns API-key onboarding (`forall verification login`),
-safe workspace snapshot packaging, job operations, and sanitized results.
-
-## External MCP surfaces
-
-The external adapters remain useful for users who choose another coding agent.
-They are not prerequisites for using standalone Forall.
-
-```text
-forall mcp-author --root <path>   # local authoring stdio adapter
-https://mcp.forall.astrio.app/mcp # hosted verification endpoint
-```
-
-## Distribution and proof toolchains
-
-The installer distributes one `forall` executable. That executable contains:
-
-- the standalone agent and native `author.*` / `verify.*` registrations;
-- the local `mcp-author` stdio adapter for external agents;
-- workflow, authoring, snapshot, and toolchain-management logic;
-- compile-time embedded schemas, templates, and skills.
-
-It does not contain every language proof engine. Toolchain ownership depends on
-the verification path:
-
-```text
-Standalone or external agent using hosted verification
-    local machine: forall binary + project files
-    hosted worker: language proof toolchains
-
-User running local `forall check`
-    local machine: forall binary + required language proof toolchains
-```
-
-Installing Forall therefore does not install all proof engines immediately.
-For local checks, `forall ensure` detects project languages and performs
-best-effort setup of the language proof engines required by each project.
-Hosted-verification users do not run these commands because the worker image
-owns those dependencies.
-
-## Hooks
-
-`forall init` merges hook definitions into `~/.forall/hooks.json` (user home, never the repo). Commands are portable (`forall hook <event>` resolved on PATH).
-
-| Hook         | Behavior                                                             |
-| ------------ | -------------------------------------------------------------------- |
-| SessionStart | Injects active change + workflow status into agent context           |
-| PreToolUse   | Blocks application-code writes until planning artifacts are complete |
-| PostToolUse  | Runs `forall sync` after TypeScript edits; records browser evidence  |
-| Stop         | Runs `forall check`; blocks completion on CRITICAL failures          |
+See [hosted-mcp.md](hosted-mcp.md).
 
 ## Project layout
 
-`forall init` writes only shareable files into the repo:
+`forall init` writes shareable files into the repo:
 
 ```text
 .forall/
-├── markers.toml            # project root markers for the agent
+├── markers.toml
 ├── workflow/
-│   ├── config.yaml         # workflow config
-│   ├── active              # active change pointer
-│   ├── changes/<name>/     # proposal, specs, design, verification, tasks
-│   └── archive/            # completed changes
+│   ├── config.yaml
+│   ├── active
+│   ├── changes/<name>/
+│   └── archive/
 ├── verify/
-│   ├── mapping.yaml        # requirement → code mapping (project marker)
-│   └── cache/              # check reports, intent, waivers
-├── specs/                  # requirements (SHALL/MUST + scenarios)
-└── scenarios/              # executable scenario / property tests
+│   ├── mapping.yaml
+│   └── cache/
+├── specs/
+└── scenarios/
 ```
 
-Machine-local state (hook registration, project trust, and managed local
-toolchains) lives in `~/.forall/`. Language-to-backend selection is built into
-the binary; the backend executables themselves are not.
-
-## Check pipeline
-
-`forall check` runs six phases: structure → mapping → proofs → intent → scenarios → scenario-tests. Reports land in `.forall/verify/cache/reports/` with a verification tier (`N proved, M spec-tracked`). Exit codes: `0` pass, `1` CRITICAL, `2` warnings.
+Machine-local state lives in `~/.forall/`.
 
 ## Spec workflow
 
@@ -173,4 +98,10 @@ the binary; the backend executables themselves are not.
 proposal → specs → design → verification → tasks → apply → archive
 ```
 
-Later steps are gated on earlier ones; the PreToolUse hook enforces the gate, and `archive` merges change specs and `mapping.delta.yaml` into project truth.
+See [workflow.md](workflow.md).
+
+## Out of scope
+
+- Local authoring MCP (`forall mcp-author`) for external agents — not a product
+  path. Authoring for other agents stays with those agents; Forall MCP is
+  verify-only.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,23 +1,38 @@
-# Getting Started
+# Getting started with Forall
 
-## Install
+Choose one path:
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/astrio-ai/forall/main/install.sh | bash
-```
+## 1. Forall CLI (full coding agent)
 
-The installer downloads the prebuilt `forall` binary for your platform into
-`~/.local/bin`. If that directory is not on your `PATH`, add it:
+Install and run Forall as your agent:
 
 ```bash
-export PATH="$HOME/.local/bin:$PATH"
+curl -fsSL https://forall.astrio.app/install.sh | bash
+forall
 ```
 
-Verify the install:
+On first launch, pick:
+
+| Option | What you do |
+|--------|-------------|
+| **Forall account** | Browser opens [forall.astrio.app/dashboard](https://forall.astrio.app/dashboard) → create a `forall_…` API key → paste it into the TUI → then choose a model provider (BYOK) for chat |
+| **Bring your own API key** | Skip the Forall key for now; set `OPENAI_API_KEY` / `OPENROUTER_API_KEY` in `~/.forall/.env` |
+
+CLI equivalent for the Forall key:
 
 ```bash
-forall --version
+printenv FORALL_API_KEY | forall verification login
+forall verification status
 ```
+
+Then initialize a project from a git repo root:
+
+```bash
+forall init
+forall
+```
+
+See [Project Layout](project-layout.md) and [Workflow](workflow.md).
 
 ### Supported platforms
 
@@ -27,25 +42,28 @@ forall --version
 | Linux | `x86_64`, `aarch64` |
 | Windows | `x86_64` |
 
-## Initialize a project
+## 2. MCP verify-only (Cursor / Claude Code / Codex)
 
-From the root of a git repository:
+Do **not** install the Forall CLI. Use the npm bridge with your existing agent:
 
-```bash
-forall init
+1. Create a key at [forall.astrio.app/dashboard](https://forall.astrio.app/dashboard)
+2. Configure MCP:
+
+```json
+{
+  "mcpServers": {
+    "forall": {
+      "command": "npx",
+      "args": ["-y", "@astrio/forall-mcp"],
+      "env": {
+        "FORALL_API_KEY": "forall_..."
+      }
+    }
+  }
+}
 ```
 
-This scaffolds a `.forall/` directory that marks the project root and holds the
-workflow and verification config. `forall init` is language-neutral — it only
-creates the workflow files.
+Hosted MCP only verifies. Your coding agent edits the workspace from the report.
 
-See [Project Layout](project-layout.md) for what gets created.
-
-## Start working
-
-```bash
-forall
-```
-
-From here, use the workflow to make changes with specs first. See
-[Workflow](workflow.md).
+See [Hosted Forall MCP](hosted-mcp.md), [packages/forall-mcp](../packages/forall-mcp/README.md), and
+[Architecture](architecture.md).

--- a/docs/hosted-mcp.md
+++ b/docs/hosted-mcp.md
@@ -1,38 +1,68 @@
 # Hosted Forall MCP
 
-## Purpose
+Remote verification for **other coding agents** (Cursor, Claude Code, Codex) and
+for the Forall CLI's native `verify.*` tools.
 
-The hosted Forall MCP server runs Forall verification remotely in isolated
-workers. It serves two product paths:
+The hosted service **does not write your workspace**. Your agent applies fixes
+from the sanitized report.
 
-- standalone Forall exposes native verification tools backed by this service;
-- external coding agents connect to the service through its public MCP tools.
+## Connect (Path B — verify-only)
 
-The hosted service never writes a user's local workspace. Local authoring is
-handled in-process by standalone Forall or through the separate
-[local authoring MCP](local-authoring-mcp.md) for external clients.
+1. Create an API key at [forall.astrio.app/dashboard](https://forall.astrio.app/dashboard)
+2. Add the npm bridge to your MCP client:
+
+```json
+{
+  "mcpServers": {
+    "forall": {
+      "command": "npx",
+      "args": ["-y", "@astrio/forall-mcp"],
+      "env": {
+        "FORALL_API_KEY": "forall_..."
+      }
+    }
+  }
+}
+```
+
+Source: [`packages/forall-mcp`](../packages/forall-mcp/README.md) (`@astrio/forall-mcp` on npm).
+
+Environment:
+
+| Variable | Required | Default |
+|----------|----------|---------|
+| `FORALL_API_KEY` | yes | — |
+| `FORALL_MCP_URL` | no | `https://mcp.forall.astrio.app/mcp` |
+
+## Forall CLI users (Path A)
+
+Standalone Forall embeds the same hosted service through native `verify.submit`,
+`verify.status`, `verify.cancel`, and `verify.explain` tools. Configure the key
+once:
+
+```bash
+printenv FORALL_API_KEY | forall verification login
+```
+
+CLI users should **not** manually add the hosted MCP URL to Forall.
 
 ## Scope
 
-The first release:
+- MCP Streamable HTTP at `https://mcp.forall.astrio.app/mcp`
+- Bearer auth with self-serve dashboard API keys (`forall_…`)
+- Inline file payloads or public GitHub repositories (immutable commit resolution)
+- Async jobs in isolated workers running the Forall verification pipeline
+- Sanitized structured reports, cancellation, and issue explanation
 
-- uses MCP Streamable HTTP at `https://mcp.forall.astrio.app/mcp`;
-- authenticates clients with Forall API keys;
-- accepts selected files supplied by an MCP client;
-- accepts public GitHub repositories and resolves refs to immutable commits;
-- runs full verification asynchronously in an isolated worker;
-- returns sanitized structured reports;
-- supports job status, cancellation, and result explanation.
-
-Private GitHub repositories, OAuth, and spec generation are deferred.
+Deferred: private GitHub repos, OAuth for repos, hosted remote authoring.
 
 ## Architecture
 
 ```text
-Standalone native verify tools or external MCP client
-    │  Streamable HTTP + API key
+MCP client (npx @astrio/forall-mcp or Forall native verify.*)
+    │  Streamable HTTP + Bearer
     ▼
-Hosted Forall MCP service
+Hosted Forall MCP
     │
     └──────────► isolated verification worker
                       │
@@ -40,77 +70,18 @@ Hosted Forall MCP service
               Forall verification pipeline
 ```
 
-Verification is asynchronous because proofs and property tests can take longer
-than MCP and proxy request timeouts. Clients submit a job and poll for its
-status and result.
-
-Standalone Forall presents this as native `verify.*` tools and manages the
-connection, source packaging, and authentication internally. Users of the
-standalone agent should not manually configure this MCP endpoint.
-
-The open-source client library in `crates/forall-hosted-verify` implements
-snapshot packaging, authenticated MCP calls, and response parsing. It does not
-contain the hosted service itself.
-
-The standalone credential flow reads the key from standard input and stores it
-through Forall's local secret store:
-
-```bash
-printenv FORALL_API_KEY | forall verification login
-```
-
-## Client and worker dependencies
-
-The hosted MCP is a service URL, not software installed on the user's machine.
-Clients need only:
-
-- standalone Forall, or an MCP-capable external coding agent;
-- a Forall API key;
-- the source files or public GitHub reference to verify.
-
-Clients do not install language proof engines for hosted jobs. The isolated
-worker image owns the complete verification runtime, including the language
-toolchains used by the workflow. Production images must provision and pin these
-dependencies during image construction; jobs must not depend on modifying the
-user's machine or discovering tools from it.
-
-This boundary applies to both product paths:
-
-```text
-Standalone Forall
-    native verify.submit → hosted worker toolchains
-
-Cursor / Claude Code / Codex
-    hosted MCP forall_verify → hosted worker toolchains
-```
-
-Local toolchains are required only for the separate local `forall check`
-pipeline. Installing the Forall executable does not eagerly install every
-proof engine; see [Architecture](architecture.md#distribution-and-proof-toolchains).
+Verification is asynchronous. Clients submit a job and poll status.
 
 ## Source inputs
-
-`forall_verify` accepts one of two source variants.
 
 ### Inline files
 
 ```json
 {
   "type": "inline",
-  "files": [
-    {
-      "path": "src/lib.rs",
-      "content": "..."
-    }
-  ]
+  "files": [{ "path": "src/lib.rs", "content": "..." }]
 }
 ```
-
-The service validates file count, file and total size, encoding, path traversal,
-symlinks, and archive expansion before dispatch.
-
-The `SnapshotPacker` in `crates/forall-hosted-verify` builds inline snapshots
-from a local workspace for clients that submit from disk.
 
 ### GitHub repository
 
@@ -123,185 +94,56 @@ from a local workspace for clients that submit from disk.
 }
 ```
 
-The service resolves the ref to an immutable commit and records that revision
-with the job. The MVP accepts public repositories only and does not run Git
-hooks or fetch submodules or Git LFS objects.
-
 ## MCP tools
 
-### `forall_verify`
+| Tool | Purpose |
+|------|---------|
+| `forall_verify` | Submit async verification job |
+| `forall_verification_status` | Poll progress and sanitized report |
+| `forall_cancel_verification` | Cancel queued/running job |
+| `forall_explain_verification` | Explain selected findings |
 
-Submits whole-project or change-scoped verification.
-
-Input:
+### `forall_verify` (submit)
 
 ```json
 {
   "source": {
     "type": "inline",
-    "files": [
-      {
-        "path": "src/lib.rs",
-        "content": "..."
-      }
-    ]
+    "files": [{ "path": "src/lib.rs", "content": "..." }]
   },
-  "scope": {
-    "type": "change",
-    "name": "add-rate-limit"
-  },
-  "strict": true,
-  "phases": [
-    "structure",
-    "mapping",
-    "proofs",
-    "intent",
-    "scenarios",
-    "property-tests",
-    "scenario-tests"
-  ],
-  "pbt_seed": 42,
-  "pbt_examples": 100
+  "scope": { "type": "project" },
+  "strict": false
 }
 ```
 
-`scope.type` is either `project` or `change`. A change scope requires `name`.
-The server applies its own maximum property-test count and job duration.
-
-Response:
-
-```json
-{
-  "job_id": "vrf_...",
-  "status": "queued",
-  "submitted_at": "2026-07-12T00:00:00Z",
-  "source_revision": "optional resolved commit SHA",
-  "poll_after_ms": 2000
-}
-```
+Response includes `job_id`, `status`, and `poll_after_ms`.
 
 ### `forall_verification_status`
 
-Returns progress and, when complete, the verification result.
-
-Input:
-
 ```json
-{
-  "job_id": "vrf_..."
-}
+{ "job_id": "vrf_..." }
 ```
 
-Possible states are `queued`, `preparing`, `running`, `succeeded`, `failed`,
-`cancelled`, and `expired`.
+States: `queued`, `preparing`, `running`, `succeeded`, `failed`, `cancelled`, `expired`.
 
-Completed response:
+### `forall_cancel_verification` / `forall_explain_verification`
 
-```json
-{
-  "job_id": "vrf_...",
-  "status": "succeeded",
-  "progress": {
-    "phase": "proofs",
-    "completed": 3,
-    "total": 7
-  },
-  "result": {
-    "ok": false,
-    "strict": true,
-    "phases": {
-      "mapping": "PASS",
-      "proofs": "FAIL"
-    },
-    "issues": [
-      {
-        "severity": "CRITICAL",
-        "phase": "proofs",
-        "requirement_id": "REQ-1",
-        "message": "...",
-        "file": "src/lib.rs",
-        "counterexample": null,
-        "proof_detail": "sanitized output"
-      }
-    ],
-    "verified_files": [
-      "src/lib.rs"
-    ],
-    "verification_summary": {
-      "total_requirements": 1,
-      "proved_requirements": 0,
-      "property_tested_requirements": 0,
-      "spec_tracked_requirements": 1
-    }
-  },
-  "error": null
-}
-```
+See tool schemas in the MCP client after connect.
 
-The public report excludes container paths, environment values, credentials,
-and unrestricted command lines.
+## Open-source client library
 
-### `forall_cancel_verification`
+[`crates/forall-hosted-verify`](../crates/forall-hosted-verify/) implements
+snapshot packaging, authenticated MCP calls, and response parsing for Rust
+integrators. It does not contain the hosted service itself.
 
-Cancels a queued or running job. Cancellation is idempotent.
+## Skills (optional)
 
-Input:
+[`skills/forall-mcp-verify`](../skills/forall-mcp-verify/SKILL.md) documents a
+verify playbook for agents that already have `.forall/` mapping and contracts in
+the workspace. Your host agent is responsible for authoring those artifacts.
 
-```json
-{
-  "job_id": "vrf_..."
-}
-```
+## Security
 
-### `forall_explain_verification`
-
-Explains selected issues from a completed report and suggests concrete
-remediation without rerunning project code.
-
-Input:
-
-```json
-{
-  "job_id": "vrf_...",
-  "issue_indexes": [
-    0
-  ],
-  "audience": "concise"
-}
-```
-
-`audience` is either `concise` or `detailed`.
-
-## Sandbox requirements
-
-Project code and verification inputs are untrusted. Every job runs in a fresh
-isolated worker with:
-
-- a non-root verification process;
-- bounded scratch storage and fixed CPU, memory, process, and wall-clock limits;
-- no general outbound network access;
-- preinstalled, pinned proof toolchains;
-- single-job, short-lived input and output access;
-- separate protected report output owned by the supervisor.
-
-Inputs and results are encrypted at rest and removed after a short retention
-period. Logs and reports redact credentials, absolute container paths, and
-environment values.
-
-## Client library
-
-The `forall-hosted-verify` crate exposes:
-
-- `HostedVerificationClient` for MCP initialize, submit, status, cancel, and explain;
-- `SnapshotPacker` for safe workspace snapshots;
-- wire types in `dto` for requests and responses.
-
-Run tests from the repository root:
-
-```bash
-cargo test -p forall-hosted-verify
-```
-
-The integration test in `tests/standalone_flow.rs` exercises authoring,
-validation, snapshot packaging, and hosted submit end-to-end against a mock MCP
-server.
+- API keys are minted/revoked at the dashboard; revoked keys fail immediately
+- Reports exclude container paths, env values, credentials, and raw command lines
+- Workers run in isolated environments with pinned proof toolchains


### PR DESCRIPTION
## Summary
- Rewrite `getting-started.md` for Path A (CLI) vs Path B (`@astrio/forall-mcp`)
- Update `architecture.md` and `hosted-mcp.md` for verify-only external MCP + dashboard keys
- Refresh `docs/README.md` index

## Test plan
- [ ] Read through getting-started and hosted-mcp links
- [ ] Confirm no references to deprecated local-authoring MCP as a product path