### PR TITLE
Document OSS crate sync with forall-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this public repository are documented here.
 
 ## Unreleased
 
+- Open-source crates verified in sync with `astrio-labs/forall-core` (`agent/forall-hosted-verify`, `agent/workflow/src/authoring`) as of 2026-07-16.
 - Add a `.forall/` project skeleton at the repo root.
 
 ## v0.1.0

--- a/crates/README.md
+++ b/crates/README.md
@@ -32,3 +32,14 @@ published here.
 
 External agents connect through [`@astrio/forall-mcp`](../packages/forall-mcp/README.md)
 for hosted verification only.
+
+## Syncing from `forall-core`
+
+Verified in sync with `astrio-labs/forall-core` as of 2026-07-16:
+
+| Public crate | Source in `forall-core` |
+| --- | --- |
+| `forall-authoring` | `agent/workflow/src/authoring/` + `mapping/schema` |
+| `forall-hosted-verify` | `agent/forall-hosted-verify/` |
+
+When copying updates, keep public integration tests on `forall_authoring::` imports.


### PR DESCRIPTION
## Summary
- Verify `forall-authoring` and `forall-hosted-verify` match `forall-core` sources
- Add sync mapping to `crates/README.md` and CHANGELOG

## Test plan
- [x] `cargo test --workspace` (crates already aligned; no source diff)