### PR TITLE
Add more CI workflows

### DIFF
--- a/.github/scripts/check-doc-links.sh
+++ b/.github/scripts/check-doc-links.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+while IFS= read -r file; do
+  [ -f "$file" ] || continue
+  while IFS= read -r link; do
+    case "$link" in
+      http:*) continue ;;
+      https:*) continue ;;
+      mailto:*) continue ;;
+      \#*) continue ;;
+    esac
+    target="${link%%#*}"
+    if [ -z "$target" ]; then
+      continue
+    fi
+    dir="$(dirname "$file")"
+    resolved="${dir}/${target}"
+    if [ ! -e "$resolved" ]; then
+      echo "::error file=$file::broken relative link: $link (resolved to $resolved)"
+      exit 1
+    fi
+  done < <(grep -oE '\]\([^)]+\)' "$file" | sed -E 's/^\]\(|\)$//g' || true)
+done < <(
+  find . \
+    \( -path './.git' -o -path './target' -o -path './packages/*/node_modules' \) -prune \
+    -o -type f -name '*.md' -print | sort
+)

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -5,19 +5,61 @@ on:
     branches: [main]
     paths:
       - 'Cargo.toml'
+      - 'Cargo.lock'
       - 'crates/**'
       - '.github/workflows/crates.yml'
   pull_request:
     paths:
       - 'Cargo.toml'
+      - 'Cargo.lock'
       - 'crates/**'
       - '.github/workflows/crates.yml'
 
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-clippy-
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
       - name: Run workspace tests
         run: cargo test --workspace

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Docs CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - 'docs/**'
+      - 'skills/**'
+      - 'CHANGELOG.md'
+      - '.github/workflows/docs.yml'
+      - '.github/scripts/check-doc-links.sh'
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'docs/**'
+      - 'skills/**'
+      - 'CHANGELOG.md'
+      - '.github/workflows/docs.yml'
+      - '.github/scripts/check-doc-links.sh'
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check internal markdown links
+        run: bash .github/scripts/check-doc-links.sh
+
+      - name: Verify required docs exist
+        run: |
+          set -euo pipefail
+          for path in \
+            docs/getting-started.md \
+            docs/hosted-mcp.md \
+            docs/architecture.md \
+            skills/forall-mcp-verify/SKILL.md; do
+            if [ ! -f "$path" ]; then
+              echo "::error::missing required doc: $path"
+              exit 1
+            fi
+          done

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,54 @@
+name: Packages CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - '.github/workflows/packages.yml'
+  pull_request:
+    paths:
+      - 'packages/**'
+      - '.github/workflows/packages.yml'
+
+jobs:
+  forall-mcp:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/forall-mcp
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: packages/forall-mcp/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Syntax check
+        run: |
+          node --check bin/forall-mcp.js
+          node --check src/index.js
+
+      - name: Smoke test (missing API key)
+        run: |
+          set +e
+          output="$(node bin/forall-mcp.js 2>&1)"
+          status=$?
+          set -e
+          echo "$output"
+          test "$status" -ne 0
+          echo "$output" | grep -q "FORALL_API_KEY is required"
+
+      - name: Verify package metadata
+        run: |
+          node -e "
+            const pkg = require('./package.json');
+            if (pkg.name !== '@astrio/forall-mcp') throw new Error('unexpected package name');
+            if (!pkg.bin?.['forall-mcp']) throw new Error('missing bin.forall-mcp');
+            if (!pkg.engines?.node) throw new Error('missing engines.node');
+          "

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,11 +1,12 @@
 name: Release smoke test
+
 on:
   workflow_dispatch:
   push:
     branches: [main]
     paths:
       - install.sh
-      - .github/workflows/release-smoke.yml
+      - '.github/workflows/release-smoke.yml'
 
 jobs:
   shellcheck:
@@ -16,3 +17,15 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y shellcheck
           shellcheck install.sh
+
+  install-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify install script metadata
+        run: |
+          set -euo pipefail
+          grep -q 'astrio-labs/forall' install.sh
+          grep -q 'FORALL_INSTALL_REPO' install.sh
+          grep -q 'forall.astrio.app/dashboard' install.sh
+          bash -n install.sh

--- a/crates/forall-authoring/src/mapping/schema.rs
+++ b/crates/forall-authoring/src/mapping/schema.rs
@@ -146,7 +146,10 @@ pub fn summarize_verification(requirements: &[Requirement]) -> VerificationSumma
 
 pub fn validate_mapping(mapping: &Mapping) -> Result<(), String> {
     if mapping.version != 1 {
-        return Err(format!("mapping version must be 1, got {}", mapping.version));
+        return Err(format!(
+            "mapping version must be 1, got {}",
+            mapping.version
+        ));
     }
     for req in &mapping.requirements {
         if req.id.is_empty() {
@@ -164,15 +167,14 @@ pub fn validate_mapping(mapping: &Mapping) -> Result<(), String> {
                 req.id
             ));
         }
-        if req.property_tested {
-            if let Some(prop) = &req.property {
-                if prop.file.is_empty() {
-                    return Err(format!(
-                        "requirement '{}' property.file must not be empty",
-                        req.id
-                    ));
-                }
-            }
+        if req.property_tested
+            && let Some(prop) = &req.property
+            && prop.file.is_empty()
+        {
+            return Err(format!(
+                "requirement '{}' property.file must not be empty",
+                req.id
+            ));
         }
         if let Some(code) = &req.code {
             if code.file.is_empty() {

--- a/crates/forall-hosted-verify/tests/standalone_flow.rs
+++ b/crates/forall-hosted-verify/tests/standalone_flow.rs
@@ -11,12 +11,6 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
 use axum::routing::post;
-use forall_hosted_verify::HostedVerificationClient;
-use forall_hosted_verify::SnapshotPacker;
-use forall_hosted_verify::StaticBearerTokenProvider;
-use forall_hosted_verify::SubmitVerificationRequest;
-use forall_hosted_verify::VerificationScope;
-use forall_hosted_verify::VerificationSource;
 use forall_authoring::authoring;
 use forall_authoring::authoring::CanonicalRoot;
 use forall_authoring::authoring::ContractTarget;
@@ -26,6 +20,12 @@ use forall_authoring::authoring::ScaffoldContractsRequest;
 use forall_authoring::authoring::UpsertRequirementsRequest;
 use forall_authoring::mapping::schema::CodeRef;
 use forall_authoring::mapping::schema::Requirement;
+use forall_hosted_verify::HostedVerificationClient;
+use forall_hosted_verify::SnapshotPacker;
+use forall_hosted_verify::StaticBearerTokenProvider;
+use forall_hosted_verify::SubmitVerificationRequest;
+use forall_hosted_verify::VerificationScope;
+use forall_hosted_verify::VerificationSource;
 use serde_json::Value;
 
 async fn hosted_mcp(headers: HeaderMap, Json(body): Json<Value>) -> Response {


### PR DESCRIPTION
## Summary
- Expand **Crates CI** with `cargo fmt`, `clippy -D warnings`, and cargo cache
- Add **Packages CI** for `@astrio/forall-mcp` (npm ci, syntax check, missing-key smoke test)
- Add **Docs CI** to verify required docs and internal markdown links
- Extend **Release smoke test** with install script metadata checks and `bash -n`
- Apply small rustfmt/clippy fixes so the new gates pass

## Test plan
- [ ] Crates CI: fmt, clippy, test jobs pass on PR
- [ ] Packages CI: forall-mcp job passes
- [ ] Docs CI: link checker passes
- [ ] Release smoke: shellcheck + install-dry-run pass

Made with [Cursor](https://cursor.com)