### PR TITLE
Catch up CHANGELOG for v0.1.0 and v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this public repository are documented here.
 
 ## Unreleased
 
+- Add open-source adapter crates: `forall-authoring` and `forall-hosted-verify`.
+- Add hosted MCP authoring skills and language contract references.
+- Hide verification implementation details from public skills.
 - Add `packages/forall-mcp` (`@astrio/forall-mcp` npm bridge source mirror).
 - Open-source crates verified in sync with `astrio-labs/forall-core` (`agent/forall-hosted-verify`, `agent/workflow/src/authoring`) as of 2026-07-16.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this public repository are documented here.
 
 ## Unreleased
 
+## v0.2.0
+
+- Prebuilt CLI binaries published as gzip-compressed GitHub Release archives.
 - Add open-source adapter crates: `forall-authoring` and `forall-hosted-verify`.
 - Add hosted MCP authoring skills and language contract references.
 - Hide verification implementation details from public skills.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ All notable changes to this public repository are documented here.
 
 - Add `packages/forall-mcp` (`@astrio/forall-mcp` npm bridge source mirror).
 - Open-source crates verified in sync with `astrio-labs/forall-core` (`agent/forall-hosted-verify`, `agent/workflow/src/authoring`) as of 2026-07-16.
-- Add a `.forall/` project skeleton at the repo root.
 
 ## v0.1.0
 
 - Initial public tree: installer, documentation, and community assets.
 - Prebuilt CLI binaries published via GitHub Releases (not built from this repo).
+- Add user-facing docs: getting started, project layout, and workflow.
+- Add brand/CLI screenshot assets and a centered README hero.
+- Point the install command at `https://forall.astrio.app/install.sh`.
+- Add a `.forall/` project skeleton at the repo root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this public repository are documented here.
 - Add open-source adapter crates: `forall-authoring` and `forall-hosted-verify`.
 - Add hosted MCP authoring skills and language contract references.
 - Hide verification implementation details from public skills.
+- Rewrite docs and README for the two-path model: Forall CLI vs `@astrio/forall-mcp` verify-only.
+- Remove deprecated Hybrid local-authoring MCP (`forall-mcp-author` crate and skill).
+- Install from gzip-compressed release archives, with fallback to raw binaries for older tags.
+- Point `install.sh` at `astrio-labs/forall` and hint at the MCP verify-only path.
 - Add `packages/forall-mcp` (`@astrio/forall-mcp` npm bridge source mirror).
 - Open-source crates verified in sync with `astrio-labs/forall-core` (`agent/forall-hosted-verify`, `agent/workflow/src/authoring`) as of 2026-07-16.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this public repository are documented here.
 - Point `install.sh` at `astrio-labs/forall` and hint at the MCP verify-only path.
 - Add `packages/forall-mcp` (`@astrio/forall-mcp` npm bridge source mirror).
 - Open-source crates verified in sync with `astrio-labs/forall-core` (`agent/forall-hosted-verify`, `agent/workflow/src/authoring`) as of 2026-07-16.
+- Expand CI with packages checks, docs link verification, Rust fmt/clippy gates, and stronger release smoke tests.
 
 ## v0.1.0
 


### PR DESCRIPTION
## Summary
- Expand `CHANGELOG.md` with missing v0.1.0 follow-ups (docs, assets, install URL, `.forall/` skeleton)
- Document open-source adapters, hosted MCP skills, two-path product model, Hybrid deprecation, compressed install, npm package mirror, and CI gates
- Cut accumulated Unreleased entries into a `## v0.2.0` section to match the published release

## Test plan
- [ ] Skim `CHANGELOG.md` against recent merged PRs (#107–#123)
- [ ] Confirm v0.2.0 section matches https://github.com/astrio-labs/forall/releases/tag/v0.2.0 themes
- [ ] Confirm Unreleased section is empty and ready for future work


Made with [Cursor](https://cursor.com)