### PR TITLE
Document v0.2.1 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this public repository are documented here.
 
 ## Unreleased
 
+## v0.2.1
+
+- Add a Feature request GitHub issue template.
+- Hide verification success cards on chat-only turns.
+- Clarify Specs tracked copy vs formal Verification passed in the TUI.
+
 ## v0.2.0
 
 - Prebuilt CLI binaries published as gzip-compressed GitHub Release archives.


### PR DESCRIPTION
## Summary
- Add a `## v0.2.1` section covering the feature-request issue template and TUI verification card/copy fixes

## Test plan
- [ ] Confirm `CHANGELOG.md` matches the intended v0.2.1 bullets
- [ ] Docs CI / link check passes if triggered


Made with [Cursor](https://cursor.com)