### PR TITLE
Add TypeScript greenfield checkout pricing example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,9 @@
 # Examples
 
-Example projects and workflows will be added here.
+Example projects for [Forall](../README.md).
+
+| Example | Language | Scenario | Description |
+|---------|----------|----------|-------------|
+| [typescript-greenfield](./typescript-greenfield/) | TypeScript | Greenfield | Multi-module checkout pricing service |
+
+See [Getting started](../docs/getting-started.md).

--- a/examples/typescript-greenfield/.forall/config.toml
+++ b/examples/typescript-greenfield/.forall/config.toml
@@ -1,0 +1,2 @@
+# Generated to match `forall init` layout.
+project_root_markers = [".forall/verified/mapping.yaml"]

--- a/examples/typescript-greenfield/.forall/config.yaml
+++ b/examples/typescript-greenfield/.forall/config.yaml
@@ -1,0 +1,10 @@
+schema: forall
+context: |
+  TypeScript checkout pricing service (integer cents).
+  Catalog SKUs → cart → one coupon → shipping → tax → quote.
+  Pure helpers in domain/money.ts are verified; orchestration and API are spec-tracked.
+rules:
+  verification:
+    - Run verification and fix CRITICAL issues before archive
+    - Keep verified: true on pure helpers in domain/money.ts
+    - Leave catalog, API, and orchestration as verified: false

--- a/examples/typescript-greenfield/.forall/specs/api/spec.md
+++ b/examples/typescript-greenfield/.forall/specs/api/spec.md
@@ -1,0 +1,10 @@
+# API
+
+## Requirements
+
+### Requirement: POST /quote returns a pricing quote for a well-formed request with known SKUs
+
+#### Scenario: well-formed-request
+
+- **WHEN** the request includes known SKUs, quantities, and an optional region
+- **THEN** the handler returns ok with a quote

--- a/examples/typescript-greenfield/.forall/specs/cart/spec.md
+++ b/examples/typescript-greenfield/.forall/specs/cart/spec.md
@@ -1,0 +1,17 @@
+# Cart
+
+## Requirements
+
+### Requirement: a cart line total is never negative when unit price and quantity are non-negative
+
+#### Scenario: non-negative-inputs
+
+- **WHEN** unit price is 500 and quantity is 3
+- **THEN** line total is 1500 and is non-negative
+
+### Requirement: cart subtotal is never negative
+
+#### Scenario: empty-or-valid-cart
+
+- **WHEN** the cart is empty or contains only non-negative line fields
+- **THEN** subtotal is >= 0

--- a/examples/typescript-greenfield/.forall/specs/catalog/spec.md
+++ b/examples/typescript-greenfield/.forall/specs/catalog/spec.md
@@ -1,0 +1,10 @@
+# Catalog
+
+## Requirements
+
+### Requirement: quote requests resolve known SKUs to catalog prices
+
+#### Scenario: known-sku
+
+- **WHEN** the request includes sku mug-01
+- **THEN** findProduct returns the catalog product with that sku

--- a/examples/typescript-greenfield/.forall/specs/coupons/spec.md
+++ b/examples/typescript-greenfield/.forall/specs/coupons/spec.md
@@ -1,0 +1,31 @@
+# Coupons
+
+## Requirements
+
+### Requirement: a percent discount never returns a price above the original or below zero
+
+#### Scenario: twenty-percent-off
+
+- **WHEN** price is 10000 cents and percent off is 20
+- **THEN** discounted price stays within [0, 10000]
+
+### Requirement: a fixed discount never exceeds the price and never goes negative
+
+#### Scenario: fixed-amount-off
+
+- **WHEN** price is 10000 cents and amount off is 1500
+- **THEN** discounted price stays within [0, 10000]
+
+### Requirement: savings after discount never exceed the configured max-discount cap
+
+#### Scenario: cap-applied
+
+- **WHEN** original is 10000, discounted is 7000, and cap is 2000
+- **THEN** capped price is 8000
+
+### Requirement: applying one coupon keeps the price between zero and the original subtotal
+
+#### Scenario: single-coupon
+
+- **WHEN** a coupon is applied to a non-negative price
+- **THEN** the result stays within [0, priceCents]

--- a/examples/typescript-greenfield/.forall/specs/quote/spec.md
+++ b/examples/typescript-greenfield/.forall/specs/quote/spec.md
@@ -1,0 +1,10 @@
+# Quote
+
+## Requirements
+
+### Requirement: a quote total equals merchandise plus shipping plus tax
+
+#### Scenario: total-equals-parts
+
+- **WHEN** a quote is built for a valid cart, coupon, region, and shipping policy
+- **THEN** total equals merchandise + shipping + tax

--- a/examples/typescript-greenfield/.forall/specs/shipping/spec.md
+++ b/examples/typescript-greenfield/.forall/specs/shipping/spec.md
@@ -1,0 +1,15 @@
+# Shipping
+
+## Requirements
+
+### Requirement: shipping fee is either zero or the flat fee and never exceeds the flat fee
+
+#### Scenario: free-over-threshold
+
+- **WHEN** merchandise is at or above the free-shipping threshold
+- **THEN** shipping fee is 0
+
+#### Scenario: flat-fee-under-threshold
+
+- **WHEN** merchandise is below the free-shipping threshold
+- **THEN** shipping fee equals the flat fee and is <= flat fee

--- a/examples/typescript-greenfield/.forall/specs/tax/spec.md
+++ b/examples/typescript-greenfield/.forall/specs/tax/spec.md
@@ -1,0 +1,10 @@
+# Tax
+
+## Requirements
+
+### Requirement: computed tax is never negative when base and rate are non-negative
+
+#### Scenario: positive-rate
+
+- **WHEN** taxable base is 8000 and rate is 825 bps
+- **THEN** tax is >= 0

--- a/examples/typescript-greenfield/.forall/verified/config.yaml
+++ b/examples/typescript-greenfield/.forall/verified/config.yaml
@@ -1,0 +1,15 @@
+backend: dafny
+strict: false
+adapters:
+  typescript:
+    proof: lemmascript-dafny
+    extensions: [ts, tsx]
+  python:
+    proof: none
+    extensions: [py]
+  rust:
+    proof: verus
+    extensions: [rs]
+  java:
+    proof: openjml
+    extensions: [java]

--- a/examples/typescript-greenfield/.forall/verified/mapping.yaml
+++ b/examples/typescript-greenfield/.forall/verified/mapping.yaml
@@ -1,0 +1,130 @@
+version: 1
+requirements:
+  - id: line-total-nonneg
+    capability: cart
+    requirement: a cart line total is never negative when unit price and quantity are non-negative
+    verified: true
+    scenarios:
+      - name: non-negative-inputs
+        kind: formal
+    code:
+      file: src/domain/money.ts
+      symbols: [lineTotal]
+    contract: "LineTotalNonNeg lineTotal"
+
+  - id: subtotal-nonneg
+    capability: cart
+    requirement: cart subtotal is never negative
+    verified: false
+    scenarios:
+      - name: empty-or-valid-cart
+        kind: manual
+    code:
+      file: src/domain/cart.ts
+      symbols: [subtotal]
+
+  - id: percent-discount-bounds
+    capability: coupons
+    requirement: a percent discount never returns a price above the original or below zero
+    verified: true
+    scenarios:
+      - name: twenty-percent-off
+        kind: formal
+    code:
+      file: src/domain/money.ts
+      symbols: [applyPercentDiscount]
+    contract: "PercentDiscountBounds applyPercentDiscount"
+
+  - id: fixed-discount-bounds
+    capability: coupons
+    requirement: a fixed discount never exceeds the price and never goes negative
+    verified: true
+    scenarios:
+      - name: fixed-amount-off
+        kind: formal
+    code:
+      file: src/domain/money.ts
+      symbols: [applyFixedDiscount]
+    contract: "FixedDiscountBounds applyFixedDiscount"
+
+  - id: max-discount-cap
+    capability: coupons
+    requirement: savings after discount never exceed the configured max-discount cap
+    verified: true
+    scenarios:
+      - name: cap-applied
+        kind: formal
+    code:
+      file: src/domain/money.ts
+      symbols: [applyDiscountCap]
+    contract: "MaxDiscountCap applyDiscountCap"
+
+  - id: single-coupon-bounds
+    capability: coupons
+    requirement: applying one coupon keeps the price between zero and the original subtotal
+    verified: false
+    scenarios:
+      - name: single-coupon
+        kind: manual
+    code:
+      file: src/domain/coupons.ts
+      symbols: [applyCoupon]
+
+  - id: tax-nonneg
+    capability: tax
+    requirement: computed tax is never negative when base and rate are non-negative
+    verified: true
+    scenarios:
+      - name: positive-rate
+        kind: formal
+    code:
+      file: src/domain/money.ts
+      symbols: [applyTax]
+    contract: "TaxNonNeg applyTax"
+
+  - id: shipping-fee-bounds
+    capability: shipping
+    requirement: shipping fee is either zero or the flat fee and never exceeds the flat fee
+    verified: true
+    scenarios:
+      - name: free-over-threshold
+        kind: formal
+      - name: flat-fee-under-threshold
+        kind: formal
+    code:
+      file: src/domain/money.ts
+      symbols: [shippingFee]
+    contract: "ShippingFeeBounds shippingFee"
+
+  - id: quote-composition
+    capability: quote
+    requirement: a quote total equals merchandise plus shipping plus tax
+    verified: false
+    scenarios:
+      - name: total-equals-parts
+        kind: manual
+    code:
+      file: src/domain/quote.ts
+      symbols: [buildQuote]
+
+  - id: catalog-sku-lookup
+    capability: catalog
+    requirement: quote requests resolve known SKUs to catalog prices
+    verified: false
+    scenarios:
+      - name: known-sku
+        kind: manual
+    code:
+      file: src/catalog/products.ts
+      symbols: [findProduct]
+
+  - id: quote-http-handler
+    capability: api
+    requirement: POST /quote returns a pricing quote for a well-formed request with known SKUs
+    verified: false
+    scenarios:
+      - name: well-formed-request
+        kind: manual
+    code:
+      file: src/api/quoteHandler.ts
+      symbols: [handleQuote]

--- a/examples/typescript-greenfield/.gitignore
+++ b/examples/typescript-greenfield/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.tsbuildinfo
+**/*.dfy
+**/*.dfy.gen
+.forall/verified/reports/
+.forall/verified/claimcheck/

--- a/examples/typescript-greenfield/README.md
+++ b/examples/typescript-greenfield/README.md
@@ -1,0 +1,44 @@
+# TypeScript greenfield — checkout pricing
+
+A small multi-module checkout pricing service with Forall specs, mapping, and
+proof contracts on the money / shipping helpers.
+
+## Layout
+
+```text
+.forall/
+  verified/mapping.yaml
+  specs/<capability>/spec.md
+src/
+  domain/
+    money.ts       # verified helpers (//@ contracts)
+    cart.ts / coupons.ts / tax.ts / shipping.ts / quote.ts
+    types.ts
+  catalog/
+    products.ts / storeConfig.ts
+  api/
+    quoteHandler.ts / healthHandler.ts
+  index.ts
+```
+
+## Run (TypeScript)
+
+```bash
+cd examples/typescript-greenfield
+npm install
+npm run check
+```
+
+## Use with Forall
+
+```bash
+cd examples/typescript-greenfield
+forall check --root .
+```
+
+## Verified vs spec-tracked
+
+| Tier | Modules |
+|------|---------|
+| Proved (`verified: true`) | `domain/money.ts` — line totals, discounts, cap, tax, shipping fee |
+| Spec-tracked | cart, coupons, tax lookup, shipping wiring, quote, catalog, API |

--- a/examples/typescript-greenfield/package-lock.json
+++ b/examples/typescript-greenfield/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "forall-example-typescript-greenfield",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "forall-example-typescript-greenfield",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/examples/typescript-greenfield/package.json
+++ b/examples/typescript-greenfield/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "forall-example-typescript-greenfield",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Forall greenfield example: checkout pricing engine with proof contracts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/typescript-greenfield/src/api/healthHandler.ts
+++ b/examples/typescript-greenfield/src/api/healthHandler.ts
@@ -1,0 +1,10 @@
+/** Conceptual GET /health. */
+
+export type HealthResponse = {
+  ok: true;
+  service: string;
+};
+
+export function handleHealth(): HealthResponse {
+  return { ok: true, service: "checkout-pricing" };
+}

--- a/examples/typescript-greenfield/src/api/quoteHandler.ts
+++ b/examples/typescript-greenfield/src/api/quoteHandler.ts
@@ -1,0 +1,62 @@
+import { findProduct } from "../catalog/products.js";
+import {
+  DEFAULT_TAX_RATE_BPS,
+  SHIPPING_POLICY,
+  TAX_RATES_BY_REGION,
+} from "../catalog/storeConfig.js";
+import { buildQuote } from "../domain/quote.js";
+import type { CartLine, Coupon, Quote } from "../domain/types.js";
+
+export type QuoteItemRequest = {
+  sku: string;
+  quantity: number;
+};
+
+export type QuoteRequest = {
+  items: QuoteItemRequest[];
+  coupon?: Coupon | null;
+  /** Region code for tax table lookup (e.g. CA, NY). */
+  region?: string;
+};
+
+export type QuoteResponse =
+  | { ok: true; quote: Quote }
+  | { ok: false; error: string };
+
+/** Conceptual POST /quote — resolve SKUs, then price the cart. */
+export function handleQuote(body: QuoteRequest): QuoteResponse {
+  if (!body || !Array.isArray(body.items) || body.items.length === 0) {
+    return { ok: false, error: "items must be a non-empty array" };
+  }
+
+  const lines: CartLine[] = [];
+  for (let i = 0; i < body.items.length; i++) {
+    const item = body.items[i];
+    if (!item || typeof item.sku !== "string" || typeof item.quantity !== "number") {
+      return { ok: false, error: "each item needs sku and quantity" };
+    }
+    if (item.quantity <= 0) {
+      return { ok: false, error: `invalid quantity for ${item.sku}` };
+    }
+    const product = findProduct(item.sku);
+    if (product === null) {
+      return { ok: false, error: `unknown sku: ${item.sku}` };
+    }
+    lines.push({
+      sku: product.sku,
+      unitPriceCents: product.unitPriceCents,
+      quantity: item.quantity,
+    });
+  }
+
+  const quote = buildQuote({
+    lines,
+    coupon: body.coupon ?? null,
+    region: body.region ?? "CA",
+    taxRatesByRegion: TAX_RATES_BY_REGION,
+    defaultTaxRateBps: DEFAULT_TAX_RATE_BPS,
+    shipping: SHIPPING_POLICY,
+  });
+
+  return { ok: true, quote };
+}

--- a/examples/typescript-greenfield/src/catalog/products.ts
+++ b/examples/typescript-greenfield/src/catalog/products.ts
@@ -1,0 +1,26 @@
+/** In-memory product catalog (spec-tracked). */
+
+export type Product = {
+  sku: string;
+  name: string;
+  unitPriceCents: number;
+};
+
+const PRODUCTS: Product[] = [
+  { sku: "mug-01", name: "Ceramic Mug", unitPriceCents: 1800 },
+  { sku: "tee-01", name: "Logo Tee", unitPriceCents: 3200 },
+  { sku: "sticker-01", name: "Sticker Pack", unitPriceCents: 500 },
+];
+
+export function listProducts(): Product[] {
+  return PRODUCTS.slice();
+}
+
+export function findProduct(sku: string): Product | null {
+  for (let i = 0; i < PRODUCTS.length; i++) {
+    if (PRODUCTS[i].sku === sku) {
+      return PRODUCTS[i];
+    }
+  }
+  return null;
+}

--- a/examples/typescript-greenfield/src/catalog/storeConfig.ts
+++ b/examples/typescript-greenfield/src/catalog/storeConfig.ts
@@ -1,0 +1,17 @@
+import type { ShippingPolicy } from "../domain/types.js";
+
+/** Store-level tax and shipping configuration. */
+
+export const DEFAULT_TAX_RATE_BPS = 825; // 8.25%
+
+export const TAX_RATES_BY_REGION: Record<string, number> = {
+  CA: 725,
+  NY: 800,
+  TX: 625,
+  WA: 650,
+};
+
+export const SHIPPING_POLICY: ShippingPolicy = {
+  flatFeeCents: 599,
+  freeThresholdCents: 5000, // free shipping at $50+
+};

--- a/examples/typescript-greenfield/src/domain/cart.ts
+++ b/examples/typescript-greenfield/src/domain/cart.ts
@@ -1,0 +1,14 @@
+import { lineTotal } from "./money.js";
+import type { CartLine } from "./types.js";
+
+/** Sum of priced line totals. */
+export function subtotal(lines: CartLine[]): number {
+  let sum = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const unit = line.unitPriceCents < 0 ? 0 : line.unitPriceCents;
+    const qty = line.quantity < 0 ? 0 : line.quantity;
+    sum = sum + lineTotal(unit, qty);
+  }
+  return sum;
+}

--- a/examples/typescript-greenfield/src/domain/coupons.ts
+++ b/examples/typescript-greenfield/src/domain/coupons.ts
@@ -1,0 +1,25 @@
+import {
+  applyDiscountCap,
+  applyFixedDiscount,
+  applyPercentDiscount,
+} from "./money.js";
+import type { Coupon } from "./types.js";
+
+function clampPercent(percentOff: number): number {
+  if (percentOff < 0) return 0;
+  if (percentOff > 100) return 100;
+  return percentOff;
+}
+
+/** Apply one coupon, then the max-discount cap. */
+export function applyCoupon(priceCents: number, coupon: Coupon): number {
+  let discounted: number;
+  if (coupon.kind === "percent") {
+    discounted = applyPercentDiscount(priceCents, clampPercent(coupon.percentOff));
+  } else {
+    const amt = coupon.amountCents < 0 ? 0 : coupon.amountCents;
+    discounted = applyFixedDiscount(priceCents, amt);
+  }
+  const cap = coupon.maxDiscountCents < 0 ? 0 : coupon.maxDiscountCents;
+  return applyDiscountCap(priceCents, discounted, cap);
+}

--- a/examples/typescript-greenfield/src/domain/money.ts
+++ b/examples/typescript-greenfield/src/domain/money.ts
@@ -1,0 +1,79 @@
+/** Pure money / fee helpers with Forall / LemmaScript contracts. */
+
+/** Line total: unit price × quantity. */
+export function lineTotal(unitPriceCents: number, quantity: number): number {
+  //@ requires unitPriceCents >= 0
+  //@ requires quantity >= 0
+  //@ ensures \result >= 0
+  //@ contract LineTotalNonNeg lineTotal
+  return unitPriceCents * quantity;
+}
+
+/** Percent-off; return value stays in [0, priceCents]. */
+export function applyPercentDiscount(priceCents: number, percentOff: number): number {
+  //@ requires priceCents >= 0
+  //@ requires 0 <= percentOff && percentOff <= 100
+  //@ ensures 0 <= \result && \result <= priceCents
+  //@ contract PercentDiscountBounds applyPercentDiscount
+  return Math.floor((priceCents * (100 - percentOff)) / 100);
+}
+
+/** Fixed-amount off; return value stays in [0, priceCents]. */
+export function applyFixedDiscount(priceCents: number, amountCents: number): number {
+  //@ requires priceCents >= 0
+  //@ requires amountCents >= 0
+  //@ ensures 0 <= \result && \result <= priceCents
+  //@ contract FixedDiscountBounds applyFixedDiscount
+  if (amountCents >= priceCents) {
+    return 0;
+  }
+  return priceCents - amountCents;
+}
+
+/** Cap savings so original − return ≤ capCents. */
+export function applyDiscountCap(
+  originalCents: number,
+  discountedCents: number,
+  capCents: number,
+): number {
+  //@ requires originalCents >= 0
+  //@ requires 0 <= discountedCents && discountedCents <= originalCents
+  //@ requires capCents >= 0
+  //@ ensures discountedCents <= \result && \result <= originalCents
+  //@ ensures originalCents - \result <= capCents
+  //@ contract MaxDiscountCap applyDiscountCap
+  const saved = originalCents - discountedCents;
+  if (saved <= capCents) {
+    return discountedCents;
+  }
+  return originalCents - capCents;
+}
+
+/** Tax rate is basis points (825 = 8.25%). */
+export function applyTax(taxableCents: number, rateBps: number): number {
+  //@ requires taxableCents >= 0
+  //@ requires rateBps >= 0
+  //@ ensures \result >= 0
+  //@ contract TaxNonNeg applyTax
+  return Math.floor((taxableCents * rateBps) / 10000);
+}
+
+/**
+ * Flat shipping, waived when merchandise reaches a free-shipping threshold.
+ * Result is either 0 or flatFeeCents.
+ */
+export function shippingFee(
+  merchandiseCents: number,
+  flatFeeCents: number,
+  freeThresholdCents: number,
+): number {
+  //@ requires merchandiseCents >= 0
+  //@ requires flatFeeCents >= 0
+  //@ requires freeThresholdCents >= 0
+  //@ ensures 0 <= \result && \result <= flatFeeCents
+  //@ contract ShippingFeeBounds shippingFee
+  if (merchandiseCents >= freeThresholdCents) {
+    return 0;
+  }
+  return flatFeeCents;
+}

--- a/examples/typescript-greenfield/src/domain/quote.ts
+++ b/examples/typescript-greenfield/src/domain/quote.ts
@@ -1,0 +1,45 @@
+import { subtotal } from "./cart.js";
+import { applyCoupon } from "./coupons.js";
+import { shippingForMerchandise } from "./shipping.js";
+import { taxForMerchandise, taxRateForRegion } from "./tax.js";
+import type { CartLine, Coupon, Quote, ShippingPolicy } from "./types.js";
+
+export type QuoteInput = {
+  lines: CartLine[];
+  coupon: Coupon | null;
+  region: string;
+  taxRatesByRegion: Record<string, number>;
+  defaultTaxRateBps: number;
+  shipping: ShippingPolicy;
+};
+
+/** Build a full checkout quote: cart → coupon → shipping → tax → total. */
+export function buildQuote(input: QuoteInput): Quote {
+  const subtotalCents = subtotal(input.lines);
+
+  let merchandiseCents: number;
+  if (input.coupon === null) {
+    merchandiseCents = subtotalCents;
+  } else {
+    merchandiseCents = applyCoupon(subtotalCents, input.coupon);
+  }
+
+  const discountCents = subtotalCents - merchandiseCents;
+  const shippingCents = shippingForMerchandise(merchandiseCents, input.shipping);
+  const rateBps = taxRateForRegion(
+    input.region,
+    input.taxRatesByRegion,
+    input.defaultTaxRateBps,
+  );
+  const taxCents = taxForMerchandise(merchandiseCents, rateBps);
+  const totalCents = merchandiseCents + shippingCents + taxCents;
+
+  return {
+    subtotalCents,
+    discountCents,
+    merchandiseCents,
+    shippingCents,
+    taxCents,
+    totalCents,
+  };
+}

--- a/examples/typescript-greenfield/src/domain/shipping.ts
+++ b/examples/typescript-greenfield/src/domain/shipping.ts
@@ -1,0 +1,13 @@
+import { shippingFee } from "./money.js";
+import type { ShippingPolicy } from "./types.js";
+
+/** Shipping cost for merchandise under a store shipping policy. */
+export function shippingForMerchandise(
+  merchandiseCents: number,
+  policy: ShippingPolicy,
+): number {
+  const merchandise = merchandiseCents < 0 ? 0 : merchandiseCents;
+  const flat = policy.flatFeeCents < 0 ? 0 : policy.flatFeeCents;
+  const threshold = policy.freeThresholdCents < 0 ? 0 : policy.freeThresholdCents;
+  return shippingFee(merchandise, flat, threshold);
+}

--- a/examples/typescript-greenfield/src/domain/tax.ts
+++ b/examples/typescript-greenfield/src/domain/tax.ts
@@ -1,0 +1,21 @@
+import { applyTax } from "./money.js";
+
+/** Resolve a tax rate (bps) from a region code using a simple table. */
+export function taxRateForRegion(
+  region: string,
+  ratesByRegion: Record<string, number>,
+  fallbackBps: number,
+): number {
+  const rate = ratesByRegion[region];
+  if (typeof rate === "number" && rate >= 0) {
+    return rate;
+  }
+  return fallbackBps < 0 ? 0 : fallbackBps;
+}
+
+/** Compute tax for merchandise using a resolved rate. */
+export function taxForMerchandise(merchandiseCents: number, rateBps: number): number {
+  const base = merchandiseCents < 0 ? 0 : merchandiseCents;
+  const rate = rateBps < 0 ? 0 : rateBps;
+  return applyTax(base, rate);
+}

--- a/examples/typescript-greenfield/src/domain/types.ts
+++ b/examples/typescript-greenfield/src/domain/types.ts
@@ -1,0 +1,34 @@
+/** Shared checkout domain types (integer cents). */
+
+export type CartLine = {
+  sku: string;
+  unitPriceCents: number;
+  quantity: number;
+};
+
+/** At most one coupon per quote. */
+export type Coupon =
+  | {
+      kind: "percent";
+      percentOff: number;
+      maxDiscountCents: number;
+    }
+  | {
+      kind: "fixed";
+      amountCents: number;
+      maxDiscountCents: number;
+    };
+
+export type Quote = {
+  subtotalCents: number;
+  discountCents: number;
+  merchandiseCents: number;
+  shippingCents: number;
+  taxCents: number;
+  totalCents: number;
+};
+
+export type ShippingPolicy = {
+  flatFeeCents: number;
+  freeThresholdCents: number;
+};

--- a/examples/typescript-greenfield/src/index.ts
+++ b/examples/typescript-greenfield/src/index.ts
@@ -1,0 +1,25 @@
+export type { CartLine, Coupon, Quote, ShippingPolicy } from "./domain/types.js";
+export {
+  lineTotal,
+  applyPercentDiscount,
+  applyFixedDiscount,
+  applyDiscountCap,
+  applyTax,
+  shippingFee,
+} from "./domain/money.js";
+export { subtotal } from "./domain/cart.js";
+export { applyCoupon } from "./domain/coupons.js";
+export { shippingForMerchandise } from "./domain/shipping.js";
+export { taxForMerchandise, taxRateForRegion } from "./domain/tax.js";
+export { buildQuote } from "./domain/quote.js";
+export type { QuoteInput } from "./domain/quote.js";
+export { listProducts, findProduct } from "./catalog/products.js";
+export type { Product } from "./catalog/products.js";
+export {
+  DEFAULT_TAX_RATE_BPS,
+  TAX_RATES_BY_REGION,
+  SHIPPING_POLICY,
+} from "./catalog/storeConfig.js";
+export { handleQuote } from "./api/quoteHandler.js";
+export type { QuoteRequest, QuoteResponse, QuoteItemRequest } from "./api/quoteHandler.js";
+export { handleHealth } from "./api/healthHandler.js";

--- a/examples/typescript-greenfield/tsconfig.json
+++ b/examples/typescript-greenfield/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Fixes #131 

Adds a TypeScript greenfield checkout pricing example under `examples/typescript-greenfield`, with Forall specs/mapping and proved money helpers.