### PR TITLE
Link TypeScript greenfield example in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,10 @@
 # Examples
 
-Example projects and workflows will be added here.
+Example projects for Forall:
+
+
+| Example                                  | Repo                                                                                                                                                       |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TypeScript greenfield (checkout pricing) | [https://github.com/radleyle/forall-examples/tree/main/typescript-greenfield](https://github.com/radleyle/forall-examples/tree/main/typescript-greenfield) |
+
+


### PR DESCRIPTION
Fixes #131 

## Summary
- Adds a link in `examples/README.md` to the TypeScript greenfield checkout pricing example
- Example source lives in https://github.com/radleyle/forall-examples/tree/main/typescript-greenfield so the main Forall repo stays lightweight

## Test plan
- [x] Open `examples/README.md` on this branch
- [x] Confirm the TypeScript greenfield link resolves to the example repo
