### PR TITLE
Fix nine security and quality issues across snapshots, the installer, scaffolding, and CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/astrio-ai/forall/blob/main/SECURITY.md
+    url: https://github.com/astrio-labs/forall/blob/main/SECURITY.md
     about: Please report security issues responsibly — do not open a public issue.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Workflow actions are pinned to commit SHAs, so this is what keeps them
+  # current once a pin goes stale.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: "/packages/forall-mcp"
+    schedule:
+      interval: weekly

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,5 +1,8 @@
 name: Crates CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -19,8 +22,8 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable branch @ 2026-08-02
         with:
           components: rustfmt
       - name: Check formatting
@@ -29,12 +32,12 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable branch @ 2026-08-02
         with:
           components: clippy
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -49,10 +52,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable branch @ 2026-08-02
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: Docs CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -23,7 +26,7 @@ jobs:
   links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Check internal markdown links
         run: bash .github/scripts/check-doc-links.sh

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,5 +1,8 @@
 name: Packages CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -18,9 +21,9 @@ jobs:
       run:
         working-directory: packages/forall-mcp
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,5 +1,8 @@
 name: Release smoke test
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:
@@ -12,7 +15,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Run shellcheck
         run: |
           sudo apt-get update && sudo apt-get install -y shellcheck
@@ -21,7 +24,7 @@ jobs:
   install-dry-run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Verify install script metadata
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this public repository are documented here.
   instead of continuing with an empty target.
 - The security policy and issue template point at `astrio-labs`, not the retired
   `astrio-ai` namespace.
+- `@astrio/forall-mcp` requires Node 20 or newer. Clearing two advisories in the
+  MCP SDK's transitive dependencies pulled in a package that needs Node 20, and
+  Node 18 has been end-of-life since April 2025.
 
 ## v0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this public repository are documented here.
 
 ## Unreleased
 
+- Security: verification snapshots no longer follow symlinked root manifests or a
+  symlinked `.forall` directory, either of which could send files from outside
+  the workspace to hosted verification.
+- Security: the hosted client and the `@astrio/forall-mcp` bridge refuse a
+  non-loopback `http://` endpoint so the bearer token is never sent in cleartext.
+- Security: `install.sh` verifies a published `<asset>.sha256` when one exists,
+  rejects release archives containing absolute or `..` member paths, and never
+  chmods a symlink out of the unpack directory. Set `FORALL_REQUIRE_CHECKSUM=1`
+  to refuse any download that cannot be verified.
+- Security: workflow actions are pinned to commit SHAs, workflows run with
+  `contents: read`, and Dependabot keeps actions, crates, and npm current.
+- Contract scaffolding no longer corrupts signatures that contain a brace before
+  the body, such as an object parameter, an object return type, or a generic bound.
+- Symbol discovery keeps nested parentheses in signatures and finds generic
+  functions in TypeScript and Rust.
+- `install.sh` now exits when it cannot support the detected OS or architecture
+  instead of continuing with an empty target.
+- The security policy and issue template point at `astrio-labs`, not the retired
+  `astrio-ai` namespace.
+
 ## v0.5.0
 
 - Sign in with GitHub: `forall login` gains GitHub alongside the browser flow — no API-key paste required.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,6 +20,6 @@ This policy covers:
 
 - The `install.sh` script in this repository
 - Documentation and community assets published here
-- Prebuilt `forall` binaries distributed via [GitHub Releases](https://github.com/astrio-ai/forall/releases)
+- Prebuilt `forall` binaries distributed via [GitHub Releases](https://github.com/astrio-labs/forall/releases)
 
 Agent source code is not published in this repository.

--- a/crates/forall-authoring/src/authoring/mod.rs
+++ b/crates/forall-authoring/src/authoring/mod.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
+use std::sync::LazyLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use regex::Regex;
@@ -12,6 +13,39 @@ use crate::mapping::schema::{Mapping, PropertyRef, Requirement, validate_mapping
 
 static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 const MAPPING_PATH: &str = ".forall/verify/mapping.yaml";
+
+// The parameter group in each pattern tolerates one level of nesting
+// (`(?:[^()]|\([^()]*\))*`) so a parameter such as `cb: fn(u32) -> u32` does
+// not truncate the captured signature at its inner `)`. The optional generic
+// group before it lists `->`/`=>` first so an arrow inside a bound is consumed
+// whole rather than read as the closing `>`.
+static TYPESCRIPT_FUNCTION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?m)^[ \t]*export[ \t]+(?:default[ \t]+)?(?:async[ \t]+)?function[ \t]+([A-Za-z_$][\w$]*)(?:<(?:=>|[^<>]|<[^<>]*>)*>)?[ \t]*(\((?:[^()]|\([^()]*\))*\))",
+    )
+    .expect("TypeScript function pattern is valid")
+});
+
+static TYPESCRIPT_ARROW: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?m)^[ \t]*export[ \t]+(?:const|let)[ \t]+([A-Za-z_$][\w$]*)[ \t]*(?::[^=\n]+)?=[ \t]*(?:async[ \t]+)?(\((?:[^()]|\([^()]*\))*\))[ \t]*(?::[^=\n]+)?=>[ \t]*\{",
+    )
+    .expect("TypeScript arrow pattern is valid")
+});
+
+static RUST_FUNCTION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?m)^[ \t]*pub(?:\([^)]*\))?[ \t]+(?:(?:async|const|unsafe)[ \t]+)*fn[ \t]+([A-Za-z_]\w*)(?:<(?:->|[^<>]|<[^<>]*>)*>)?[ \t]*(\((?:[^()]|\([^()]*\))*\))",
+    )
+    .expect("Rust function pattern is valid")
+});
+
+static JAVA_METHOD: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?m)^[ \t]*public[ \t]+(?:static[ \t]+)?(?:final[ \t]+)?[\w<>\[\], ?]+[ \t]+([A-Za-z_]\w*)[ \t]*(\((?:[^()]|\([^()]*\))*\))[ \t]*(?:throws[^{]+)?\{",
+    )
+    .expect("Java method pattern is valid")
+});
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -853,19 +887,11 @@ fn parse_symbols(
     language: SourceLanguage,
     source: &str,
 ) -> AuthoringResult<Vec<DiscoveredSymbol>> {
-    let pattern = match language {
-        SourceLanguage::TypeScript => {
-            r"(?m)^[ \t]*export[ \t]+(?:default[ \t]+)?(?:async[ \t]+)?function[ \t]+([A-Za-z_$][\w$]*)[ \t]*(\([^)]*\))"
-        }
-        SourceLanguage::Rust => {
-            r"(?m)^[ \t]*pub(?:\([^)]*\))?[ \t]+(?:(?:async|const|unsafe)[ \t]+)*fn[ \t]+([A-Za-z_]\w*)[ \t]*(\([^)]*\))"
-        }
-        SourceLanguage::Java => {
-            r"(?m)^[ \t]*public[ \t]+(?:static[ \t]+)?(?:final[ \t]+)?[\w<>\[\], ?]+[ \t]+([A-Za-z_]\w*)[ \t]*(\([^)]*\))[ \t]*(?:throws[^{]+)?\{"
-        }
+    let regex = match language {
+        SourceLanguage::TypeScript => &*TYPESCRIPT_FUNCTION,
+        SourceLanguage::Rust => &*RUST_FUNCTION,
+        SourceLanguage::Java => &*JAVA_METHOD,
     };
-    let regex =
-        Regex::new(pattern).map_err(|err| error(AuthoringErrorCode::Malformed, err.to_string()))?;
     let mut output = Vec::new();
     for captures in regex.captures_iter(source) {
         let (Some(full), Some(name), Some(params)) =
@@ -895,11 +921,7 @@ fn parse_symbols(
         });
     }
     if language == SourceLanguage::TypeScript {
-        let arrow = Regex::new(
-            r"(?m)^[ \t]*export[ \t]+(?:const|let)[ \t]+([A-Za-z_$][\w$]*)[ \t]*(?::[^=\n]+)?=[ \t]*(?:async[ \t]+)?(\([^)]*\))[ \t]*=>[ \t]*\{",
-        )
-        .map_err(|err| error(AuthoringErrorCode::Malformed, err.to_string()))?;
-        for captures in arrow.captures_iter(source) {
+        for captures in TYPESCRIPT_ARROW.captures_iter(source) {
             let (Some(full), Some(name), Some(params)) =
                 (captures.get(0), captures.get(1), captures.get(2))
             else {
@@ -948,7 +970,7 @@ fn contract_insertion(
     match language {
         SourceLanguage::TypeScript => {
             let tail = &source[line_start..];
-            let brace = body_brace(tail, target)?;
+            let brace = body_brace(tail, language, symbol, target)?;
             let offset = line_start + brace + 1;
             let inner = format!("{indent}  ");
             let existing = leading_contract_lines(&tail[brace + 1..], "//@");
@@ -986,7 +1008,7 @@ fn contract_insertion(
         }
         SourceLanguage::Rust => {
             let tail = &source[line_start..];
-            let brace = body_brace(tail, target)?;
+            let brace = body_brace(tail, language, symbol, target)?;
             let offset = line_start + brace;
             let clause_indent = format!("{indent}    ");
             let existing = &tail[..brace];
@@ -1018,22 +1040,194 @@ fn contract_insertion(
     }
 }
 
-fn body_brace(tail: &str, target: &ContractTarget) -> AuthoringResult<usize> {
-    let brace = tail.find('{').ok_or_else(|| {
+/// Byte offset of the `{` that opens the function body, searching from the
+/// start of the symbol's first line. Generic bounds, the parameter list,
+/// strings and comments are stepped over so their braces are never mistaken
+/// for the body.
+fn body_brace(
+    tail: &str,
+    language: SourceLanguage,
+    symbol: &DiscoveredSymbol,
+    target: &ContractTarget,
+) -> AuthoringResult<usize> {
+    let bytes = tail.as_bytes();
+    let malformed = |detail: &str| {
         path_error(
             AuthoringErrorCode::Malformed,
             &target.file,
-            format!("symbol '{}' has no function body", target.symbol),
+            format!("symbol '{}' {detail}", target.symbol),
         )
-    })?;
-    if tail.find(';').is_some_and(|semicolon| semicolon < brace) {
-        return Err(path_error(
-            AuthoringErrorCode::Malformed,
-            &target.file,
-            format!("symbol '{}' has no writable function body", target.symbol),
-        ));
+    };
+
+    let mut index = tail
+        .find(symbol.name.as_str())
+        .map_or(0, |start| start + symbol.name.len());
+    index = skip_trivia(bytes, index);
+    if bytes.get(index) == Some(&b'<') {
+        index = match_generics(bytes, index, language)
+            .ok_or_else(|| malformed("has an unterminated generic parameter list"))?;
     }
-    Ok(brace)
+    let open =
+        scan_to(bytes, index, language, b'(').ok_or_else(|| malformed("has no parameter list"))?;
+    index = match_delimiter(bytes, open, language)
+        .ok_or_else(|| malformed("has an unterminated parameter list"))?;
+
+    loop {
+        index = skip_trivia(bytes, index);
+        match bytes.get(index) {
+            None => return Err(malformed("has no function body")),
+            Some(b';') => return Err(malformed("has no writable function body")),
+            Some(b'{') => {
+                let close = match_delimiter(bytes, index, language)
+                    .ok_or_else(|| malformed("has an unterminated function body"))?;
+                // A TypeScript return type can itself be an object literal
+                // (`): { ok: boolean } {`); the body is what follows it.
+                if language == SourceLanguage::TypeScript
+                    && bytes.get(skip_trivia(bytes, close)) == Some(&b'{')
+                {
+                    index = skip_trivia(bytes, close);
+                    continue;
+                }
+                return Ok(index);
+            }
+            Some(b'"' | b'\'' | b'`') => index = skip_quoted(bytes, index, language),
+            Some(_) => index += 1,
+        }
+    }
+}
+
+/// Index of the next `target` byte that is real code, skipping over string
+/// literals and comments.
+fn scan_to(bytes: &[u8], mut index: usize, language: SourceLanguage, target: u8) -> Option<usize> {
+    while let Some(byte) = bytes.get(index) {
+        match *byte {
+            byte if byte == target => return Some(index),
+            b'"' | b'\'' | b'`' => index = skip_quoted(bytes, index, language),
+            b'/' if matches!(bytes.get(index + 1), Some(b'/' | b'*')) => {
+                index = skip_trivia(bytes, index);
+            }
+            _ => index += 1,
+        }
+    }
+    None
+}
+
+fn skip_trivia(bytes: &[u8], mut index: usize) -> usize {
+    loop {
+        match bytes.get(index) {
+            Some(byte) if byte.is_ascii_whitespace() => index += 1,
+            Some(b'/') => match bytes.get(index + 1) {
+                Some(b'/') => {
+                    index += 2;
+                    while bytes.get(index).is_some_and(|byte| *byte != b'\n') {
+                        index += 1;
+                    }
+                }
+                Some(b'*') => {
+                    index += 2;
+                    while index < bytes.len()
+                        && !(bytes[index] == b'*' && bytes.get(index + 1) == Some(&b'/'))
+                    {
+                        index += 1;
+                    }
+                    index = bytes.len().min(index + 2);
+                }
+                _ => return index,
+            },
+            _ => return index,
+        }
+    }
+}
+
+/// Index just past the closing quote of the literal starting at `index`. A
+/// Rust lifetime (`'a`) is not a literal, so it advances a single byte.
+fn skip_quoted(bytes: &[u8], index: usize, language: SourceLanguage) -> usize {
+    let quote = bytes[index];
+    if quote == b'\'' && language == SourceLanguage::Rust && !is_char_literal(bytes, index) {
+        return index + 1;
+    }
+    let mut cursor = index + 1;
+    while let Some(byte) = bytes.get(cursor) {
+        match *byte {
+            b'\\' => cursor += 2,
+            byte if byte == quote => return cursor + 1,
+            _ => cursor += 1,
+        }
+    }
+    cursor
+}
+
+fn is_char_literal(bytes: &[u8], index: usize) -> bool {
+    match bytes.get(index + 1) {
+        Some(b'\\') => true,
+        Some(_) => bytes.get(index + 2) == Some(&b'\''),
+        None => false,
+    }
+}
+
+/// Index just past the bracket matching the one at `open`.
+fn match_delimiter(bytes: &[u8], open: usize, language: SourceLanguage) -> Option<usize> {
+    let opening = *bytes.get(open)?;
+    let closing = match opening {
+        b'(' => b')',
+        b'[' => b']',
+        b'{' => b'}',
+        _ => return None,
+    };
+    let mut depth = 0_usize;
+    let mut index = open;
+    while let Some(byte) = bytes.get(index) {
+        match *byte {
+            b'"' | b'\'' | b'`' => {
+                index = skip_quoted(bytes, index, language);
+                continue;
+            }
+            b'/' if matches!(bytes.get(index + 1), Some(b'/' | b'*')) => {
+                index = skip_trivia(bytes, index);
+                continue;
+            }
+            byte if byte == opening => depth += 1,
+            byte if byte == closing => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(index + 1);
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    None
+}
+
+/// Index just past the `>` closing the generic list at `open`. Arrow and
+/// return tokens (`=>`, `->`) are consumed whole so their `>` does not read
+/// as a closing bracket.
+fn match_generics(bytes: &[u8], open: usize, language: SourceLanguage) -> Option<usize> {
+    let mut depth = 0_usize;
+    let mut index = open;
+    while let Some(byte) = bytes.get(index) {
+        match *byte {
+            b'"' | b'\'' | b'`' => {
+                index = skip_quoted(bytes, index, language);
+            }
+            b'=' | b'-' if bytes.get(index + 1) == Some(&b'>') => index += 2,
+            b'(' => index = match_delimiter(bytes, index, language)?,
+            b'<' => {
+                depth += 1;
+                index += 1;
+            }
+            b'>' => {
+                depth -= 1;
+                index += 1;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            _ => index += 1,
+        }
+    }
+    None
 }
 
 fn leading_contract_lines(source: &str, marker: &str) -> String {

--- a/crates/forall-authoring/src/authoring/mod.rs
+++ b/crates/forall-authoring/src/authoring/mod.rs
@@ -14,35 +14,74 @@ use crate::mapping::schema::{Mapping, PropertyRef, Requirement, validate_mapping
 static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 const MAPPING_PATH: &str = ".forall/verify/mapping.yaml";
 
-// The parameter group in each pattern tolerates one level of nesting
-// (`(?:[^()]|\([^()]*\))*`) so a parameter such as `cb: fn(u32) -> u32` does
-// not truncate the captured signature at its inner `)`. The optional generic
-// group before it lists `->`/`=>` first so an arrow inside a bound is consumed
-// whole rather than read as the closing `>`.
+/// A parenthesised parameter list. One level of nesting keeps a parameter such
+/// as `cb: fn(u32) -> u32` from truncating the captured signature at its inner
+/// `)`.
+const PARAMETERS: &str = r"(\((?:[^()]|\([^()]*\))*\))";
+
+/// How deeply a generic argument list may nest before the pattern stops
+/// recognising it — `IntoIterator<Item = Vec<u8>>` needs three. A regex cannot
+/// balance brackets to arbitrary depth, so this is a bound, not a parser.
+const GENERIC_DEPTH: usize = 4;
+
+/// An optional generic parameter list to sit between a function name and its
+/// parameters. Arrow tokens are listed first so the `>` in `->` or `=>` inside
+/// a bound is consumed whole rather than read as the closing bracket.
+fn optional_generics(depth: usize) -> String {
+    let inner = if depth == 0 {
+        "[^<>]*".to_string()
+    } else {
+        format!("(?:->|=>|[^<>]|{})*", optional_generics(depth - 1))
+    };
+    format!("<{inner}>")
+}
+
 static TYPESCRIPT_FUNCTION: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?m)^[ \t]*export[ \t]+(?:default[ \t]+)?(?:async[ \t]+)?function[ \t]+([A-Za-z_$][\w$]*)(?:<(?:=>|[^<>]|<[^<>]*>)*>)?[ \t]*(\((?:[^()]|\([^()]*\))*\))",
+        &[
+            r"(?m)^[ \t]*export[ \t]+(?:default[ \t]+)?(?:async[ \t]+)?function[ \t]+([A-Za-z_$][\w$]*)(?:",
+            &optional_generics(GENERIC_DEPTH),
+            r")?[ \t]*",
+            PARAMETERS,
+        ]
+        .concat(),
     )
     .expect("TypeScript function pattern is valid")
 });
 
 static TYPESCRIPT_ARROW: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?m)^[ \t]*export[ \t]+(?:const|let)[ \t]+([A-Za-z_$][\w$]*)[ \t]*(?::[^=\n]+)?=[ \t]*(?:async[ \t]+)?(\((?:[^()]|\([^()]*\))*\))[ \t]*(?::[^=\n]+)?=>[ \t]*\{",
+        &[
+            r"(?m)^[ \t]*export[ \t]+(?:const|let)[ \t]+([A-Za-z_$][\w$]*)[ \t]*(?::[^=\n]+)?=[ \t]*(?:async[ \t]+)?",
+            PARAMETERS,
+            r"[ \t]*(?::[^=\n]+)?=>[ \t]*\{",
+        ]
+        .concat(),
     )
     .expect("TypeScript arrow pattern is valid")
 });
 
 static RUST_FUNCTION: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?m)^[ \t]*pub(?:\([^)]*\))?[ \t]+(?:(?:async|const|unsafe)[ \t]+)*fn[ \t]+([A-Za-z_]\w*)(?:<(?:->|[^<>]|<[^<>]*>)*>)?[ \t]*(\((?:[^()]|\([^()]*\))*\))",
+        &[
+            r"(?m)^[ \t]*pub(?:\([^)]*\))?[ \t]+(?:(?:async|const|unsafe)[ \t]+)*fn[ \t]+([A-Za-z_]\w*)(?:",
+            &optional_generics(GENERIC_DEPTH),
+            r")?[ \t]*",
+            PARAMETERS,
+        ]
+        .concat(),
     )
     .expect("Rust function pattern is valid")
 });
 
 static JAVA_METHOD: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?m)^[ \t]*public[ \t]+(?:static[ \t]+)?(?:final[ \t]+)?[\w<>\[\], ?]+[ \t]+([A-Za-z_]\w*)[ \t]*(\((?:[^()]|\([^()]*\))*\))[ \t]*(?:throws[^{]+)?\{",
+        &[
+            r"(?m)^[ \t]*public[ \t]+(?:static[ \t]+)?(?:final[ \t]+)?[\w<>\[\], ?]+[ \t]+([A-Za-z_]\w*)[ \t]*",
+            PARAMETERS,
+            r"[ \t]*(?:throws[^{]+)?\{",
+        ]
+        .concat(),
     )
     .expect("Java method pattern is valid")
 });
@@ -1072,17 +1111,25 @@ fn body_brace(
     index = match_delimiter(bytes, open, language)
         .ok_or_else(|| malformed("has an unterminated parameter list"))?;
 
+    let mut annotated = false;
     loop {
         index = skip_trivia(bytes, index);
         match bytes.get(index) {
             None => return Err(malformed("has no function body")),
             Some(b';') => return Err(malformed("has no writable function body")),
+            Some(b':') if language == SourceLanguage::TypeScript => {
+                annotated = true;
+                index += 1;
+            }
             Some(b'{') => {
-                let close = match_delimiter(bytes, index, language)
-                    .ok_or_else(|| malformed("has an unterminated function body"))?;
                 // A TypeScript return type can itself be an object literal
-                // (`): { ok: boolean } {`); the body is what follows it.
-                if language == SourceLanguage::TypeScript
+                // (`): { ok: boolean } {`), in which case the body is what
+                // follows it. Only look ahead inside an annotation: a type is
+                // always balanced, whereas a body need not be — `return /{/`
+                // is legal — and an unbalanced body is taken at face value
+                // rather than rejected.
+                if annotated
+                    && let Some(close) = match_delimiter(bytes, index, language)
                     && bytes.get(skip_trivia(bytes, close)) == Some(&b'{')
                 {
                     index = skip_trivia(bytes, close);

--- a/crates/forall-authoring/src/authoring/tests.rs
+++ b/crates/forall-authoring/src/authoring/tests.rs
@@ -223,6 +223,109 @@ fn golden_contract_edits_for_three_languages() {
 }
 
 #[test]
+fn contracts_open_the_body_past_braces_in_signatures() {
+    let (_dir, root) = root();
+    // Every signature here carries a `{` before the one that opens the body:
+    // an object parameter, an object return type, and a generic bound.
+    write(
+        &root,
+        "src/pricing.ts",
+        "export function total(order: { net: number }, rate: number): number {\n  return order.net * rate;\n}\n",
+    );
+    write(
+        &root,
+        "src/shape.ts",
+        "export function shape(x: number): { ok: boolean } {\n  return { ok: x > 0 };\n}\n",
+    );
+    write(
+        &root,
+        "src/apply.rs",
+        "pub fn apply<F: Fn(u32) -> u32>(f: F, x: u32) -> u32 {\n    f(x)\n}\n",
+    );
+    let mutation = apply_for(&root, &["src/pricing.ts", "src/shape.ts", "src/apply.rs"]);
+    scaffold_contracts(
+        &root,
+        &ScaffoldContractsRequest {
+            contracts: vec![
+                ContractTarget {
+                    file: "src/pricing.ts".into(),
+                    symbol: "total".into(),
+                    requires: vec!["rate > 0".into()],
+                    ensures: vec![],
+                },
+                ContractTarget {
+                    file: "src/shape.ts".into(),
+                    symbol: "shape".into(),
+                    requires: vec!["x !== 0".into()],
+                    ensures: vec![],
+                },
+                ContractTarget {
+                    file: "src/apply.rs".into(),
+                    symbol: "apply".into(),
+                    requires: vec!["x > 0".into()],
+                    ensures: vec![],
+                },
+            ],
+            mutation,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        fs::read_to_string(root.as_path().join("src/pricing.ts")).unwrap(),
+        "export function total(order: { net: number }, rate: number): number {\n  //@ requires rate > 0\n  return order.net * rate;\n}\n"
+    );
+    assert_eq!(
+        fs::read_to_string(root.as_path().join("src/shape.ts")).unwrap(),
+        "export function shape(x: number): { ok: boolean } {\n  //@ requires x !== 0\n  return { ok: x > 0 };\n}\n"
+    );
+    assert_eq!(
+        fs::read_to_string(root.as_path().join("src/apply.rs")).unwrap(),
+        "pub fn apply<F: Fn(u32) -> u32>(f: F, x: u32) -> u32 \n    requires x > 0,\n{\n    f(x)\n}\n"
+    );
+}
+
+#[test]
+fn discovered_signatures_keep_nested_parentheses() {
+    let (_dir, root) = root();
+    write(
+        &root,
+        "src/lib.rs",
+        "pub fn label(map: Vec<u32>, cb: fn(u32) -> u32) -> u32 {\n    0\n}\n",
+    );
+    let discovered = discover_symbols(&root, &["src/lib.rs".to_string()]).unwrap();
+    assert_eq!(
+        discovered.symbols[0].signature,
+        "label(map: Vec<u32>, cb: fn(u32) -> u32)"
+    );
+}
+
+#[test]
+fn discovery_finds_generic_and_annotated_arrow_functions() {
+    let (_dir, root) = root();
+    write(
+        &root,
+        "src/pick.ts",
+        "export function pick<T extends { id: string }>(v: T): string {\n  return v.id;\n}\n",
+    );
+    write(
+        &root,
+        "src/scale.ts",
+        "export const scale = (x: number): number => {\n  return x;\n};\n",
+    );
+    let discovered = discover_symbols(
+        &root,
+        &["src/pick.ts".to_string(), "src/scale.ts".to_string()],
+    )
+    .unwrap();
+    let names: Vec<_> = discovered
+        .symbols
+        .iter()
+        .map(|symbol| symbol.name.as_str())
+        .collect();
+    assert_eq!(names, ["pick", "scale"]);
+}
+
+#[test]
 fn contract_missing_and_ambiguous_symbols_are_structured_errors() {
     let (_dir, root) = root();
     write(

--- a/crates/forall-authoring/src/authoring/tests.rs
+++ b/crates/forall-authoring/src/authoring/tests.rs
@@ -300,6 +300,55 @@ fn discovered_signatures_keep_nested_parentheses() {
 }
 
 #[test]
+fn contracts_reach_bodies_that_do_not_balance() {
+    let (_dir, root) = root();
+    // The `{` inside this regex literal never closes, so the body cannot be
+    // balanced. The insertion point is still known and must still be used.
+    write(
+        &root,
+        "src/brace.ts",
+        "export function hasBrace(s: string): boolean {\n  return /{/.test(s);\n}\n",
+    );
+    let mutation = apply_for(&root, &["src/brace.ts"]);
+    scaffold_contracts(
+        &root,
+        &ScaffoldContractsRequest {
+            contracts: vec![ContractTarget {
+                file: "src/brace.ts".into(),
+                symbol: "hasBrace".into(),
+                requires: vec!["s.length > 0".into()],
+                ensures: vec![],
+            }],
+            mutation,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        fs::read_to_string(root.as_path().join("src/brace.ts")).unwrap(),
+        "export function hasBrace(s: string): boolean {\n  //@ requires s.length > 0\n  return /{/.test(s);\n}\n"
+    );
+}
+
+#[test]
+fn discovery_handles_deeply_nested_generic_bounds() {
+    let (_dir, root) = root();
+    write(
+        &root,
+        "src/parse.rs",
+        "pub fn parse<T: IntoIterator<Item = Vec<u8>>>(input: T) -> usize {\n    0\n}\n",
+    );
+    let discovered = discover_symbols(&root, &["src/parse.rs".to_string()]).unwrap();
+    assert_eq!(
+        discovered
+            .symbols
+            .iter()
+            .map(|symbol| symbol.name.as_str())
+            .collect::<Vec<_>>(),
+        ["parse"]
+    );
+}
+
+#[test]
 fn discovery_finds_generic_and_annotated_arrow_functions() {
     let (_dir, root) = root();
     write(

--- a/crates/forall-hosted-verify/src/client.rs
+++ b/crates/forall-hosted-verify/src/client.rs
@@ -218,7 +218,7 @@ impl HostedVerificationClient {
         });
         let response = self.post(&token, Some(session), &request).await?;
         let result = validate_json_rpc_response(&response.body, token.expose())?;
-        let payload = tool_payload(result)?;
+        let payload = tool_payload(result, token.expose())?;
         serde_json::from_value(payload)
             .map_err(|error| HostedVerifyError::InvalidResponse(error.to_string()))
     }
@@ -229,6 +229,7 @@ impl HostedVerificationClient {
         session_id: Option<&str>,
         body: &Value,
     ) -> Result<McpResponse, HostedVerifyError> {
+        ensure_secure_endpoint(&self.endpoint)?;
         let mut request = self
             .http
             .post(&self.endpoint)
@@ -284,6 +285,22 @@ struct McpResponse {
     session_id: Option<String>,
 }
 
+/// Refuse to attach the bearer token to a request that would leave the host in
+/// cleartext. Loopback stays allowed so local servers keep working.
+fn ensure_secure_endpoint(endpoint: &str) -> Result<(), HostedVerifyError> {
+    let url = reqwest::Url::parse(endpoint)
+        .map_err(|error| HostedVerifyError::InvalidEndpoint(error.to_string()))?;
+    let loopback = matches!(
+        url.host_str(),
+        Some("localhost" | "127.0.0.1" | "[::1]" | "::1")
+    );
+    match url.scheme() {
+        "https" => Ok(()),
+        "http" if loopback => Ok(()),
+        scheme => Err(HostedVerifyError::InsecureEndpoint(scheme.to_string())),
+    }
+}
+
 fn validate_json_rpc_response<'a>(
     body: &'a Value,
     token: &str,
@@ -304,19 +321,19 @@ fn validate_json_rpc_response<'a>(
         .ok_or_else(|| HostedVerifyError::InvalidResponse("missing JSON-RPC result".to_string()))
 }
 
-fn tool_payload(result: &Value) -> Result<Value, HostedVerifyError> {
+fn tool_payload(result: &Value, token: &str) -> Result<Value, HostedVerifyError> {
     if result.get("isError").and_then(Value::as_bool) == Some(true) {
         let structured = result.get("structuredContent");
         let code = structured
             .and_then(|value| value.get("code"))
             .and_then(Value::as_str)
             .unwrap_or("tool_failed")
-            .to_string();
+            .replace(token, "[REDACTED]");
         let message = structured
             .and_then(|value| value.get("message"))
             .and_then(Value::as_str)
             .unwrap_or("hosted verification tool reported failure")
-            .to_string();
+            .replace(token, "[REDACTED]");
         return Err(HostedVerifyError::ToolFailed { code, message });
     }
     if let Some(structured) = result.get("structuredContent") {
@@ -361,6 +378,12 @@ pub enum HostedVerifyError {
     Transport(reqwest::Error),
     #[error("hosted MCP returned HTTP {0}")]
     HttpStatus(u16),
+    #[error("hosted MCP endpoint is not a valid URL: {0}")]
+    InvalidEndpoint(String),
+    #[error(
+        "hosted MCP endpoint uses {0}; https is required so the bearer token is not sent in cleartext"
+    )]
+    InsecureEndpoint(String),
     #[error("hosted MCP initialize response omitted Mcp-Session-Id")]
     MissingSessionId,
     #[error("hosted MCP error {code}: {message}")]

--- a/crates/forall-hosted-verify/src/snapshot.rs
+++ b/crates/forall-hosted-verify/src/snapshot.rs
@@ -163,7 +163,15 @@ impl SnapshotPacker {
 
 fn collect_forall_files(root: &Path, paths: &mut BTreeSet<PathBuf>) -> Result<(), SnapshotError> {
     let forall_dir = root.join(".forall");
-    if !forall_dir.exists() {
+    // `WalkDir` follows a symlinked walk root even with `follow_links(false)`,
+    // so the root has to be rejected here rather than per entry below.
+    let Some(metadata) = optional_symlink_metadata(&forall_dir)? else {
+        return Ok(());
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(SnapshotError::Symlink(relative_path(root, &forall_dir)?));
+    }
+    if !metadata.is_dir() {
         return Ok(());
     }
     let entries = WalkDir::new(&forall_dir).follow_links(false).into_iter();
@@ -267,11 +275,32 @@ fn collect_support_files(root: &Path, paths: &mut BTreeSet<PathBuf>) -> Result<(
     ];
     for relative in EXACT {
         let path = root.join(relative);
-        if path.is_file() {
+        // `Path::is_file` follows symlinks, which would pull a file from
+        // outside the workspace into the snapshot.
+        let Some(metadata) = optional_symlink_metadata(&path)? else {
+            continue;
+        };
+        if metadata.file_type().is_symlink() {
+            return Err(SnapshotError::Symlink(relative_path(root, &path)?));
+        }
+        if metadata.is_file() {
             paths.insert(path);
         }
     }
     Ok(())
+}
+
+/// Metadata for `path` without following a terminal symlink, treating a
+/// missing path as `None` rather than an error.
+fn optional_symlink_metadata(path: &Path) -> Result<Option<fs::Metadata>, SnapshotError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(SnapshotError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
 }
 
 fn add_selected_file(

--- a/crates/forall-hosted-verify/src/tests.rs
+++ b/crates/forall-hosted-verify/src/tests.rs
@@ -367,6 +367,77 @@ fn snapshot_rejects_symlinks_without_following_them() {
     ));
 }
 
+#[tokio::test]
+async fn a_plaintext_endpoint_is_refused_before_the_token_is_sent() {
+    // Nothing is listening on this host; reaching the network at all would be
+    // a transport error rather than the rejection asserted here.
+    let refused = client("http://mcp.example.com/mcp".to_string())
+        .initialize()
+        .await;
+    assert!(matches!(
+        refused,
+        Err(HostedVerifyError::InsecureEndpoint(scheme)) if scheme == "http"
+    ));
+
+    let accepted = client("https://mcp.example.com/mcp".to_string())
+        .initialize()
+        .await;
+    assert!(!matches!(
+        accepted,
+        Err(HostedVerifyError::InsecureEndpoint(_))
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn verification_snapshot_rejects_symlinked_support_files() {
+    use std::os::unix::fs::symlink;
+
+    let root = TempDir::new().expect("tempdir");
+    let outside = TempDir::new().expect("outside");
+    write(outside.path(), "secret.txt", "secret");
+    write(
+        root.path(),
+        ".forall/verify/mapping.yaml",
+        "version: 1\nrequirements: []\n",
+    );
+    // A root manifest is picked up by name, so it must not be a way to read a
+    // file from outside the workspace.
+    symlink(
+        outside.path().join("secret.txt"),
+        root.path().join("Cargo.toml"),
+    )
+    .expect("symlink");
+
+    assert!(matches!(
+        SnapshotPacker::default().pack_verification_workspace(root.path()),
+        Err(SnapshotError::Symlink(path)) if path == std::path::Path::new("Cargo.toml")
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn verification_snapshot_rejects_a_symlinked_forall_directory() {
+    use std::os::unix::fs::symlink;
+
+    let root = TempDir::new().expect("tempdir");
+    let outside = TempDir::new().expect("outside");
+    write(
+        outside.path(),
+        "verify/mapping.yaml",
+        "version: 1\nrequirements: []\n",
+    );
+    write(outside.path(), "private.txt", "secret");
+    // `WalkDir` follows a symlinked walk root, so `.forall` itself has to be
+    // rejected before the walk starts.
+    symlink(outside.path(), root.path().join(".forall")).expect("symlink");
+
+    assert!(matches!(
+        SnapshotPacker::default().pack_verification_workspace(root.path()),
+        Err(SnapshotError::Symlink(path)) if path == std::path::Path::new(".forall")
+    ));
+}
+
 #[test]
 fn github_helper_has_explicit_wire_variant() {
     let source = github_source("owner/repository", "main", Some("packages/app".to_string()));

--- a/install.sh
+++ b/install.sh
@@ -39,10 +39,74 @@ latest_release_tag() {
 # Prefer an existing binary from PATH for extraction tools only when needed.
 have_cmd() { command -v "$1" >/dev/null 2>&1; }
 
+# A regular file that is not a symlink, so `chmod +x` cannot follow a link the
+# archive planted to a file outside the extraction directory.
+is_plain_file() { [ -f "$1" ] && [ ! -L "$1" ]; }
+
 download() {
   local url="$1"
   local out="$2"
   curl -fsSL "$url" -o "$out"
+}
+
+sha256_of() {
+  local file="$1"
+  if have_cmd sha256sum; then
+    sha256sum "$file" | awk '{print $1}'
+  elif have_cmd shasum; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  elif have_cmd openssl; then
+    openssl dgst -sha256 "$file" | awk '{print $NF}'
+  else
+    return 1
+  fi
+}
+
+# Compare "$file" against the "<asset>.sha256" published beside it. Exits 0 on
+# a match, 1 on a mismatch, and 2 when no digest is published or no digest tool
+# is available — the caller decides what to do about 2.
+verify_checksum() {
+  local file="$1" url="$2" digest expected actual
+  digest="$(mktemp)"
+  if ! curl -fsSL "${url}.sha256" -o "$digest" 2>/dev/null; then
+    rm -f "$digest"
+    return 2
+  fi
+  expected="$(tr -d '\r' <"$digest" | awk 'NR==1 {print $1}')"
+  rm -f "$digest"
+  if [ -z "$expected" ]; then
+    return 2
+  fi
+  if ! actual="$(sha256_of "$file")"; then
+    err "no sha256 tool found (sha256sum, shasum, or openssl); cannot verify the download"
+    return 2
+  fi
+  [ "$actual" = "$expected" ]
+}
+
+# Apply the checksum policy to a freshly downloaded file. An unverifiable
+# download is fatal when FORALL_REQUIRE_CHECKSUM=1 and a loud warning otherwise,
+# because releases do not publish digests yet.
+enforce_checksum() {
+  local file="$1" url="$2" asset status=0
+  asset="$(basename "$url")"
+  verify_checksum "$file" "$url" || status=$?
+  case "$status" in
+    0)
+      info "Verified sha256 for ${asset}"
+      ;;
+    2)
+      if [ "${FORALL_REQUIRE_CHECKSUM:-0}" = "1" ]; then
+        err "no published sha256 for ${asset} and FORALL_REQUIRE_CHECKSUM=1"
+        return 1
+      fi
+      err "warning: no published sha256 for ${asset}; this download is unverified"
+      ;;
+    *)
+      err "sha256 mismatch for ${asset}; refusing to install"
+      return 1
+      ;;
+  esac
 }
 
 install_from_archive() {
@@ -69,17 +133,39 @@ install_from_archive() {
     cleanup
     return 1
   fi
+
+  if ! enforce_checksum "$archive" "$url"; then
+    trap - EXIT
+    cleanup
+    exit 1
+  fi
+
+  # Reject absolute or parent-relative members before unpacking so the archive
+  # cannot write outside the extraction directory.
+  local listing
+  if ! listing="$(tar -tzf "$archive")"; then
+    err "release archive could not be read"
+    trap - EXIT
+    cleanup
+    return 1
+  fi
+  if printf '%s\n' "$listing" | grep -qE '^/|(^|/)\.\.(/|$)'; then
+    err "release archive contains unsafe member paths; refusing to extract"
+    trap - EXIT
+    cleanup
+    exit 1
+  fi
   tar -xzf "$archive" -C "$extract_dir"
 
   binary="${extract_dir}/${expected_name}"
-  if [ ! -f "$binary" ]; then
+  if ! is_plain_file "$binary"; then
     # Tolerate archives that store just "forall" / "forall.exe".
-    if [ -f "${extract_dir}/${BINARY_NAME}" ]; then
+    if is_plain_file "${extract_dir}/${BINARY_NAME}"; then
       binary="${extract_dir}/${BINARY_NAME}"
-    elif [ -f "${extract_dir}/${BINARY_NAME}.exe" ]; then
+    elif is_plain_file "${extract_dir}/${BINARY_NAME}.exe"; then
       binary="${extract_dir}/${BINARY_NAME}.exe"
     else
-      err "archive did not contain ${expected_name}"
+      err "archive did not contain ${expected_name} as a regular file"
       trap - EXIT
       cleanup
       return 1
@@ -100,14 +186,23 @@ install_raw_binary() {
     rm -f "$tmp"
     return 1
   fi
+  if ! enforce_checksum "$tmp" "$url"; then
+    rm -f "$tmp"
+    exit 1
+  fi
   chmod +x "$tmp"
   mv "$tmp" "${INSTALL_DIR}/${BINARY_NAME}"
 }
 
 main() {
-  local os arch tag base url
+  local os arch tag base url platform
   mkdir -p "$INSTALL_DIR"
-  read -r os arch <<<"$(detect_platform)"
+  # `exit` inside a command substitution only leaves the subshell, so the
+  # unsupported-platform failure has to be propagated explicitly.
+  if ! platform="$(detect_platform)"; then
+    exit 1
+  fi
+  read -r os arch <<<"$platform"
   tag="$(latest_release_tag || true)"
   if [ -z "${tag:-}" ]; then
     err "no release found at https://github.com/${REPO}/releases yet."

--- a/packages/forall-mcp/package-lock.json
+++ b/packages/forall-mcp/package-lock.json
@@ -23,24 +23,24 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -465,9 +465,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/packages/forall-mcp/package.json
+++ b/packages/forall-mcp/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "keywords": [
     "mcp",

--- a/packages/forall-mcp/src/index.js
+++ b/packages/forall-mcp/src/index.js
@@ -21,9 +21,22 @@ export async function main() {
     );
   }
 
-  const mcpUrl = process.env.FORALL_MCP_URL?.trim() || DEFAULT_MCP_URL;
+  const mcpUrl = new URL(process.env.FORALL_MCP_URL?.trim() || DEFAULT_MCP_URL);
+  const loopback = ["localhost", "127.0.0.1", "[::1]", "::1"].includes(
+    mcpUrl.hostname,
+  );
+  // The API key travels as a bearer header, so refuse any endpoint that would
+  // put it on the wire in cleartext.
+  const secure =
+    mcpUrl.protocol === "https:" || (mcpUrl.protocol === "http:" && loopback);
+  if (!secure) {
+    throw new Error(
+      `FORALL_MCP_URL uses ${mcpUrl.protocol}; https is required so the API key is not sent in cleartext`,
+    );
+  }
+
   const remote = new Client({ name: "forall-mcp-bridge", version: "0.1.0" });
-  const transport = new StreamableHTTPClientTransport(new URL(mcpUrl), {
+  const transport = new StreamableHTTPClientTransport(mcpUrl, {
     requestInit: {
       headers: {
         Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION
An independent audit pass over the Rust crates, the JS MCP bridge, the installer, and CI. Nine issues, each reproduced before being fixed. The suite goes from 27 to 33 tests; clippy, rustfmt, shellcheck, the doc-link checker, and `node --check` are all clean.

Commits are split so no file spans two of them, so any one is independently revertable.

## Security

**Two symlink escapes in verification snapshots** (`56c1b97`). `collect_support_files` used `Path::is_file` on the root manifests it picks up by name, and `collect_forall_files` guarded each walk entry but not the walk root — `WalkDir` follows a symlinked root even with `follow_links(false)`. Either one let a repository ship files from anywhere on disk to the hosted verifier. Reproduced both, e.g. `Cargo.toml` symlinked outside the root packed as `Cargo.toml => "TOP-SECRET-OUTSIDE-REPO\n"`. Both now stat with `symlink_metadata` and fail closed, matching the `SnapshotError::Symlink` contract the rest of the module already kept.

**The API key could go out in cleartext** (`56c1b97`). Neither `with_endpoint` nor the bridge's `FORALL_MCP_URL` validated the URL scheme. Both now require https outside loopback, checked before the token is attached. `tool_payload` also redacts the token from server-supplied failures, which `validate_json_rpc_response` already did.

**Unverified installer downloads** (`b1d9646`). `install.sh` fetched a release asset and moved it onto PATH without checking it against anything. It now verifies a published `<asset>.sha256`, refuses archives with absolute or `..` members, and requires the unpacked binary to be a regular file so `chmod +x` cannot follow a planted symlink. **See the open question below** — this warns rather than fails today.

**CI hardening** (`1b4b817`). No workflow declared `permissions`, and `dtolnay/rust-toolchain@stable` was a mutable branch reference. All four actions are now pinned to commit SHAs under `contents: read`, with a Dependabot config so the pins don't rot.

**Security-policy links pointed at a namespace we renamed away from** (`1b4b817`). `SECURITY.md` and the issue template referenced `astrio-ai/forall`; those resolve only through GitHub's rename redirect, which stops working if anyone claims the name. Poor property for the two links a vulnerability reporter follows.

## Quality

**Contract scaffolding corrupted source files** (`de9aaef`). `body_brace` took the first `{` after the symbol's line as the body, so any brace in the signature won. Scaffolding onto `export function total(order: { net: number }, rate: number)` produced:

```ts
export function total(order: {
  //@ requires rate > 0 net: number }, rate: number): number {
```

Invalid TypeScript, written to disk, reported as a successful update. Replaced with a scanner that steps over the generic list, parameter list, strings and comments, and recognises a TypeScript object return type as not being the body. Verified against ten signature shapes including doc comments containing braces, `"{"` string defaults, multi-line params, Rust `where` clauses, lifetimes, and char literals in the body.

**Symbol discovery truncated and missed signatures** (`de9aaef`). The `\([^)]*\)` parameter group stopped at the first nested `)`, so `cb: fn(u32) -> u32` reported a signature ending mid-parameter — and since Java uses the signature as its selector, that left affected methods unaddressable. Fixing it exposed two more gaps: generic functions were never discovered in TypeScript or Rust, and neither were arrow functions with a return type annotation. The four patterns also moved to `LazyLock` so they compile once rather than twice per file scanned.

**The installer continued past an unsupported platform** (`b1d9646`). `detect_platform`'s `exit 1` ran inside a command substitution, so it only left the subshell; users saw a confusing failure downloading `forall--` instead of the message written for them.

## Open questions for review

1. **The checksum check warns rather than fails when no digest is published**, because no release ships one today — v0.5.0 back through v0.2.0 have only the five `.tar.gz` assets. `FORALL_REQUIRE_CHECKSUM=1` opts into strict mode now. This only becomes a real control once the release pipeline (private repo, not touched here) publishes `<asset>.sha256`; the default should flip to fail-closed at that point.
2. **`SECURITY.md` still names no reporting address** — it says to email "the maintainers at Astrio AI" with no address, so there is currently no working private disclosure path. Needs either an address or GitHub private vulnerability reporting enabled.

## Added during review

**Two open Dependabot advisories cleared** (`ce8d4eb`). Pushing the branch surfaced a high-severity host-confusion issue in `fast-uri` and a Windows path-traversal issue in `@hono/node-server`, both transitive through the MCP SDK and both pre-existing on `main`. `npm audit fix` resolves them by moving the SDK 1.29.0 → 1.30.0, inside the existing `^1.12.1` range, so `package.json` is unchanged. `npm audit` now reports zero.

**Node floor raised to 20** (`819028d`). Greptile caught that the refreshed lockfile pins `@hono/node-server` 2.0.12, which declares `engines.node >=20`, while the package advertised `>=18` — Node 18/19 consumers would have hit an engine warning or failed install, and CI runs Node 22 so nothing here would have caught it. Node 18 has been EOL since April 2025. Worth noting separately: Node 20 left maintenance in April 2026, so a floor of 22 may be the better long-term answer.

**Two Codex findings on the new brace scanner** (`bfb876e`). Both reproduced as failing tests before being fixed. First, balancing the TypeScript body to identify an object return type broke on regex literals — `return /{/.test(s);` counted an unmatched `{` and scaffolding refused the file, a regression against the old first-brace search. The lookahead is now gated on a return-type annotation, where braces belong to a type and are always balanced, and an unbalanced body is taken at face value. Second, the generic group allowed only one nesting level, so `pub fn parse<T: IntoIterator<Item = Vec<u8>>>` was dropped from discovery; it is now composed to a bounded depth of four. A regex cannot balance brackets arbitrarily, so that is a bound rather than a parser, and the code says so.

## Verification

`cargo test --workspace` (33 passing), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `shellcheck install.sh .github/scripts/check-doc-links.sh`, `bash .github/scripts/check-doc-links.sh`, `node --check`. The installer guards were driven through a fake curl/gh/uname harness: unsupported platform, checksum mismatch, and traversal archive each exit 1 with nothing installed; a matching checksum installs normally. The endpoint guard was checked live — `https://` reaches the real server and returns a clean auth error, `http://` and `ws://` are refused before any request, `http://localhost` still works.

