### PR TITLE
Proof-view Phase 0 (public half): C authoring mirror + wire-conformance twins

### DIFF
--- a/crates/forall-authoring/src/authoring/mod.rs
+++ b/crates/forall-authoring/src/authoring/mod.rs
@@ -86,15 +86,25 @@ static JAVA_METHOD: LazyLock<Regex> = LazyLock::new(|| {
     .expect("Java method pattern is valid")
 });
 
+/// A GCC/Clang `__attribute__((...))` specifier, with one level of nested
+/// parentheses inside the double parens (`aligned(4)`, `format(printf, 1, 2)`).
+const C_ATTRIBUTE: &str = r"__attribute__[ \t]*\(\((?:[^()]|\([^()]*\))*\)\)";
+
 /// Top-level definitions only (no indentation), body brace on the same line
 /// or the next (Allman braces are common in C). Prototypes end in `;` after
 /// the parameter list, so they fail the `{`/end-of-line alternative. Control
 /// statements that sneak past the shape (`else if (x) {`) are dropped by the
-/// keyword filter in `parse_symbols`.
+/// keyword filter in `parse_symbols`. Attributes may lead the declaration or
+/// sit between type tokens and the name — common in exactly the firmware
+/// code this targets.
 static C_FUNCTION: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         &[
-            r"(?m)^(?:static[ \t]+)?(?:inline[ \t]+)?[A-Za-z_]\w*(?:[ \t]+[A-Za-z_]\w*)*[ \t*]+([A-Za-z_]\w*)[ \t]*",
+            r"(?m)^(?:static[ \t]+)?(?:inline[ \t]+)?(?:",
+            C_ATTRIBUTE,
+            r"[ \t]+)?[A-Za-z_]\w*(?:[ \t]+(?:",
+            C_ATTRIBUTE,
+            r"|[A-Za-z_]\w*))*[ \t*]+([A-Za-z_]\w*)[ \t]*",
             PARAMETERS,
             r"[ \t]*(?:\{|$)",
         ]
@@ -464,10 +474,14 @@ pub fn discover_project_symbols(
     languages: &[SourceLanguage],
 ) -> AuthoringResult<DiscoverSymbolsOutput> {
     let selected: BTreeSet<SourceLanguage> = if languages.is_empty() {
+        // Every supported language: an omission here silently filters a
+        // language out of project-wide discovery while direct file discovery
+        // still works, which reads as "no symbols found" rather than an error.
         [
             SourceLanguage::TypeScript,
             SourceLanguage::Rust,
             SourceLanguage::Java,
+            SourceLanguage::C,
         ]
         .into_iter()
         .collect()

--- a/crates/forall-authoring/src/authoring/mod.rs
+++ b/crates/forall-authoring/src/authoring/mod.rs
@@ -86,6 +86,27 @@ static JAVA_METHOD: LazyLock<Regex> = LazyLock::new(|| {
     .expect("Java method pattern is valid")
 });
 
+/// Top-level definitions only (no indentation), body brace on the same line
+/// or the next (Allman braces are common in C). Prototypes end in `;` after
+/// the parameter list, so they fail the `{`/end-of-line alternative. Control
+/// statements that sneak past the shape (`else if (x) {`) are dropped by the
+/// keyword filter in `parse_symbols`.
+static C_FUNCTION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        &[
+            r"(?m)^(?:static[ \t]+)?(?:inline[ \t]+)?[A-Za-z_]\w*(?:[ \t]+[A-Za-z_]\w*)*[ \t*]+([A-Za-z_]\w*)[ \t]*",
+            PARAMETERS,
+            r"[ \t]*(?:\{|$)",
+        ]
+        .concat(),
+    )
+    .expect("C function pattern is valid")
+});
+
+const C_KEYWORDS: &[&str] = &[
+    "if", "else", "for", "while", "switch", "return", "sizeof", "do",
+];
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AuthoringErrorCode {
@@ -375,6 +396,7 @@ pub enum SourceLanguage {
     TypeScript,
     Rust,
     Java,
+    C,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -423,7 +445,7 @@ pub fn discover_symbols(
             path_error(
                 AuthoringErrorCode::Malformed,
                 file,
-                "supported source extensions are .ts, .tsx, .rs, and .java",
+                "supported source extensions are .ts, .tsx, .rs, .java, .c, and .h",
             )
         })?;
         output
@@ -917,6 +939,7 @@ fn language_for_path(file: &str) -> Option<SourceLanguage> {
         "ts" | "tsx" => Some(SourceLanguage::TypeScript),
         "rs" => Some(SourceLanguage::Rust),
         "java" => Some(SourceLanguage::Java),
+        "c" | "h" => Some(SourceLanguage::C),
         _ => None,
     }
 }
@@ -930,6 +953,7 @@ fn parse_symbols(
         SourceLanguage::TypeScript => &*TYPESCRIPT_FUNCTION,
         SourceLanguage::Rust => &*RUST_FUNCTION,
         SourceLanguage::Java => &*JAVA_METHOD,
+        SourceLanguage::C => &*C_FUNCTION,
     };
     let mut output = Vec::new();
     for captures in regex.captures_iter(source) {
@@ -939,6 +963,9 @@ fn parse_symbols(
             continue;
         };
         let name = name.as_str().to_string();
+        if language == SourceLanguage::C && C_KEYWORDS.contains(&name.as_str()) {
+            continue;
+        }
         let params = params.as_str();
         let signature = format!("{name}{params}");
         let selector = if language == SourceLanguage::Java {
@@ -1028,7 +1055,10 @@ fn contract_insertion(
             Ok((!annotations.is_empty())
                 .then(|| (offset, format!("{eol}{}", annotations.join(eol)))))
         }
-        SourceLanguage::Java => {
+        // JML and ACSL share the `//@` line-annotation form above the
+        // declaration, so Java and C scaffold identically; only the checker
+        // downstream differs (OpenJML vs Frama-C).
+        SourceLanguage::Java | SourceLanguage::C => {
             let existing = trailing_contract_lines(&source[..line_start], "//@");
             for clause in &target.requires {
                 let line = format!("{indent}//@ requires {clause}");

--- a/crates/forall-authoring/src/authoring/tests.rs
+++ b/crates/forall-authoring/src/authoring/tests.rs
@@ -184,6 +184,13 @@ fn discovers_c_functions_and_filters_control_flow() {
             "frame_status_t frame_validate(const uint8_t *buf, size_t len) {\n",
             "    return FRAME_OK;\n",
             "}\n",
+            "int __attribute__((warn_unused_result)) parse_frame(void)\n",
+            "{\n",
+            "    return 0;\n",
+            "}\n",
+            "__attribute__((noreturn)) void die(void) {\n",
+            "    for (;;) {}\n",
+            "}\n",
             "void frame_reset(void);\n",
         ),
     );
@@ -191,7 +198,10 @@ fn discovers_c_functions_and_filters_control_flow() {
     let symbols: Vec<&str> = found.symbols.iter().map(|s| s.symbol.as_str()).collect();
     // Definitions with Allman and same-line braces are found; the `else if`
     // inside a body and the trailing prototype are not.
-    assert_eq!(symbols, vec!["crc16", "frame_validate"]);
+    assert_eq!(
+        symbols,
+        vec!["crc16", "frame_validate", "parse_frame", "die"]
+    );
     assert_eq!(found.symbols[0].line, 2);
     assert_eq!(
         found.symbols[1].signature,

--- a/crates/forall-authoring/src/authoring/tests.rs
+++ b/crates/forall-authoring/src/authoring/tests.rs
@@ -163,6 +163,78 @@ fn discovers_three_languages_and_overloads() {
 }
 
 #[test]
+fn discovers_c_functions_and_filters_control_flow() {
+    let (_dir, root) = root();
+    write(
+        &root,
+        "src/frame.c",
+        concat!(
+            "#include \"frame.h\"\n",
+            "static uint16_t crc16(const uint8_t *data, size_t len)\n",
+            "{\n",
+            "    uint16_t crc = 0;\n",
+            "    if (len == 0) {\n",
+            "        return crc;\n",
+            "    }\n",
+            "    else if (len > MAX) {\n",
+            "        return crc;\n",
+            "    }\n",
+            "    return crc;\n",
+            "}\n",
+            "frame_status_t frame_validate(const uint8_t *buf, size_t len) {\n",
+            "    return FRAME_OK;\n",
+            "}\n",
+            "void frame_reset(void);\n",
+        ),
+    );
+    let found = discover_symbols(&root, &["src/frame.c".into()]).unwrap();
+    let symbols: Vec<&str> = found.symbols.iter().map(|s| s.symbol.as_str()).collect();
+    // Definitions with Allman and same-line braces are found; the `else if`
+    // inside a body and the trailing prototype are not.
+    assert_eq!(symbols, vec!["crc16", "frame_validate"]);
+    assert_eq!(found.symbols[0].line, 2);
+    assert_eq!(
+        found.symbols[1].signature,
+        "frame_validate(const uint8_t *buf, size_t len)"
+    );
+}
+
+#[test]
+fn golden_contract_edit_for_c_places_acsl_above_declaration() {
+    let (_dir, root) = root();
+    write(
+        &root,
+        "src/frame.c",
+        "static uint16_t crc16(const uint8_t *data, size_t len)\n{\n    return 0;\n}\n",
+    );
+    let mutation = apply_for(&root, &["src/frame.c"]);
+    scaffold_contracts(
+        &root,
+        &ScaffoldContractsRequest {
+            contracts: vec![ContractTarget {
+                file: "src/frame.c".into(),
+                symbol: "crc16".into(),
+                requires: vec![r"\valid_read(data + (0 .. len - 1));".into()],
+                ensures: vec![r"\result == crc16_spec(data, len);".into()],
+            }],
+            mutation,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        fs::read_to_string(root.as_path().join("src/frame.c")).unwrap(),
+        concat!(
+            "//@ requires \\valid_read(data + (0 .. len - 1));\n",
+            "//@ ensures \\result == crc16_spec(data, len);\n",
+            "static uint16_t crc16(const uint8_t *data, size_t len)\n",
+            "{\n",
+            "    return 0;\n",
+            "}\n",
+        )
+    );
+}
+
+#[test]
 fn golden_contract_edits_for_three_languages() {
     let (_dir, root) = root();
     write(

--- a/crates/forall-hosted-verify/tests/fixtures/wire/failed_status.json
+++ b/crates/forall-hosted-verify/tests/fixtures/wire/failed_status.json
@@ -1,0 +1,12 @@
+{
+  "contract_version": 1,
+  "job_id": "job_7b6c5d4e3f2a",
+  "status": "failed",
+  "submitted_at": "2026-08-02T18:04:05Z",
+  "updated_at": "2026-08-02T18:05:10Z",
+  "error": {
+    "code": "worker_crashed",
+    "message": "verification worker exited before producing a report",
+    "retryable": true
+  }
+}

--- a/crates/forall-hosted-verify/tests/fixtures/wire/running_status.json
+++ b/crates/forall-hosted-verify/tests/fixtures/wire/running_status.json
@@ -1,0 +1,12 @@
+{
+  "contract_version": 1,
+  "job_id": "job_0c1d2e3f4a5b",
+  "status": "running",
+  "submitted_at": "2026-08-02T18:04:05Z",
+  "updated_at": "2026-08-02T18:04:52Z",
+  "progress": {
+    "phase": "proofs",
+    "completed": 3,
+    "total": 7
+  }
+}

--- a/crates/forall-hosted-verify/tests/fixtures/wire/succeeded_status.json
+++ b/crates/forall-hosted-verify/tests/fixtures/wire/succeeded_status.json
@@ -1,0 +1,51 @@
+{
+  "contract_version": 1,
+  "job_id": "job_9f3a2c11d4e5",
+  "status": "succeeded",
+  "submitted_at": "2026-08-02T18:04:05Z",
+  "updated_at": "2026-08-02T18:06:41Z",
+  "source_revision": "4f2c9c3c1a0b7d6e5f4a3b2c1d0e9f8a7b6c5d4e",
+  "result": {
+    "ok": false,
+    "strict": true,
+    "phases": {
+      "structure": "PASS",
+      "mapping": "PASS",
+      "proofs": "FAIL",
+      "intent": "PASS",
+      "scenarios": "SKIP",
+      "property-tests": "PASS",
+      "scenario-tests": "SKIP"
+    },
+    "issues": [
+      {
+        "severity": "CRITICAL",
+        "phase": "proofs",
+        "requirement_id": "REQ-007",
+        "message": "proof check failed for src/frame.c (requirements: REQ-007): goal frame_validate_ensures unproved",
+        "file": "src/frame.c",
+        "proof_detail": "tool: framac Frama-C 32.1 (Iron)\nstdout:\n[wp] Proved goals: 13 / 14\nstderr:\n"
+      },
+      {
+        "severity": "WARNING",
+        "phase": "property-tests",
+        "requirement_id": "REQ-014",
+        "message": "property run shrank a failing case",
+        "file": "src/dose.c",
+        "counterexample": { "requested": 4294967295, "limit": 100 }
+      },
+      {
+        "severity": "INFO",
+        "phase": "proofs",
+        "message": "proofs failed with the toolchain available; inspect the goal list"
+      }
+    ],
+    "verified_files": ["src/frame.c", "src/crc.c"],
+    "verification_summary": {
+      "total_requirements": 9,
+      "proved_requirements": 4,
+      "property_tested_requirements": 2,
+      "spec_tracked_requirements": 3
+    }
+  }
+}

--- a/crates/forall-hosted-verify/tests/wire_conformance.rs
+++ b/crates/forall-hosted-verify/tests/wire_conformance.rs
@@ -7,11 +7,15 @@
 //! crate, these fixtures are what stops silent drift. Change a wire type or
 //! fixture on either side and you must update the twin in the same change.
 //!
-//! Client types deliberately do NOT round-trip to identical JSON (absent
-//! optionals serialize as explicit nulls here), so this side asserts parsed
-//! values and re-parse stability, not byte equality.
+//! Client types deliberately do NOT serialize back to byte-identical JSON
+//! (absent optionals become explicit nulls here), so equality is asserted
+//! structurally: every field the fixture carries must survive the round trip
+//! with the same value. Fields the client drops or renames therefore fail
+//! here even when no assertion below happens to name them.
 
 use std::path::Path;
+
+use serde_json::Value;
 
 use forall_hosted_verify::{
     StatusVerificationResponse, VerificationIssueSeverity, VerificationPhaseStatus,
@@ -25,16 +29,43 @@ fn fixture(name: &str) -> String {
     std::fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()))
 }
 
+/// Every key the fixture has, at every depth, must be present in the client's
+/// re-serialization with an equal value. Extra keys on the client side (the
+/// null-filled optionals) are allowed; missing or changed ones are not — that
+/// is the drift this suite exists to catch.
+fn assert_covers(fixture: &Value, client: &Value, path: &str) {
+    match fixture {
+        Value::Object(expected) => {
+            let actual = client
+                .as_object()
+                .unwrap_or_else(|| panic!("{path}: client dropped object"));
+            for (key, value) in expected {
+                let found = actual
+                    .get(key)
+                    .unwrap_or_else(|| panic!("{path}/{key}: field missing after round trip"));
+                assert_covers(value, found, &format!("{path}/{key}"));
+            }
+        }
+        Value::Array(expected) => {
+            let actual = client
+                .as_array()
+                .unwrap_or_else(|| panic!("{path}: client dropped array"));
+            assert_eq!(expected.len(), actual.len(), "{path}: array length changed");
+            for (index, value) in expected.iter().enumerate() {
+                assert_covers(value, &actual[index], &format!("{path}[{index}]"));
+            }
+        }
+        scalar => assert_eq!(scalar, client, "{path}: value changed after round trip"),
+    }
+}
+
 fn parse(name: &str) -> StatusVerificationResponse {
     let raw = fixture(name);
     let parsed: StatusVerificationResponse =
         serde_json::from_str(&raw).expect("server fixture parses with client DTOs");
-    // Re-serialize and re-parse: whatever the client emits must at least be
-    // stable under its own parser, or downstream caching breaks.
-    let reserialized = serde_json::to_string(&parsed).expect("client DTO serializes");
-    let reparsed: StatusVerificationResponse =
-        serde_json::from_str(&reserialized).expect("client DTO re-parses its own output");
-    assert_eq!(parsed, reparsed, "{name}: client DTO not self-stable");
+    let reserialized = serde_json::to_value(&parsed).expect("client DTO serializes");
+    let original: Value = serde_json::from_str(&raw).expect("fixture is JSON");
+    assert_covers(&original, &reserialized, name);
     parsed
 }
 

--- a/crates/forall-hosted-verify/tests/wire_conformance.rs
+++ b/crates/forall-hosted-verify/tests/wire_conformance.rs
@@ -1,0 +1,93 @@
+//! Wire-contract conformance: the fixtures under tests/fixtures/wire/ are
+//! byte-identical copies of the canonical server fixtures in the private repo
+//! (mcp-host/tests/fixtures/wire/, exercised there against the server's own
+//! DTOs with a strict round-trip). This side proves the hand-mirrored client
+//! DTOs still parse exactly what the server emits. The wire types exist in
+//! three hand-synced Rust copies plus a Python lambda; until they share a
+//! crate, these fixtures are what stops silent drift. Change a wire type or
+//! fixture on either side and you must update the twin in the same change.
+//!
+//! Client types deliberately do NOT round-trip to identical JSON (absent
+//! optionals serialize as explicit nulls here), so this side asserts parsed
+//! values and re-parse stability, not byte equality.
+
+use std::path::Path;
+
+use forall_hosted_verify::{
+    StatusVerificationResponse, VerificationIssueSeverity, VerificationPhaseStatus,
+    VerificationStatus,
+};
+
+fn fixture(name: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/wire")
+        .join(name);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", path.display()))
+}
+
+fn parse(name: &str) -> StatusVerificationResponse {
+    let raw = fixture(name);
+    let parsed: StatusVerificationResponse =
+        serde_json::from_str(&raw).expect("server fixture parses with client DTOs");
+    // Re-serialize and re-parse: whatever the client emits must at least be
+    // stable under its own parser, or downstream caching breaks.
+    let reserialized = serde_json::to_string(&parsed).expect("client DTO serializes");
+    let reparsed: StatusVerificationResponse =
+        serde_json::from_str(&reserialized).expect("client DTO re-parses its own output");
+    assert_eq!(parsed, reparsed, "{name}: client DTO not self-stable");
+    parsed
+}
+
+#[test]
+fn succeeded_status_parses_with_the_full_report() {
+    let response = parse("succeeded_status.json");
+
+    assert_eq!(response.contract_version, 1);
+    assert_eq!(response.status, VerificationStatus::Succeeded);
+    assert_eq!(
+        response.source_revision.as_deref(),
+        Some("4f2c9c3c1a0b7d6e5f4a3b2c1d0e9f8a7b6c5d4e")
+    );
+    let result = response.result.expect("succeeded job carries a report");
+    assert!(!result.ok);
+    assert_eq!(
+        result.phases.get("proofs"),
+        Some(&VerificationPhaseStatus::Fail)
+    );
+    assert_eq!(result.issues.len(), 3);
+    let critical = &result.issues[0];
+    assert_eq!(critical.severity, VerificationIssueSeverity::Critical);
+    assert_eq!(critical.requirement_id.as_deref(), Some("REQ-007"));
+    assert!(
+        critical
+            .proof_detail
+            .as_deref()
+            .is_some_and(|detail| detail.starts_with("tool: ")),
+        "proofs-phase detail leads with the prover identity line"
+    );
+    assert!(result.issues[1].counterexample.is_some());
+    assert!(result.issues[2].requirement_id.is_none());
+    assert_eq!(result.verification_summary.total_requirements, 9);
+    assert_eq!(result.verification_summary.proved_requirements, 4);
+}
+
+#[test]
+fn running_status_parses_with_progress_only() {
+    let response = parse("running_status.json");
+    assert_eq!(response.status, VerificationStatus::Running);
+    assert!(response.result.is_none());
+    assert!(response.error.is_none());
+    let progress = response.progress.expect("running job reports progress");
+    assert_eq!((progress.completed, progress.total), (3, 7));
+}
+
+#[test]
+fn failed_status_parses_with_a_retryable_error() {
+    let response = parse("failed_status.json");
+    assert_eq!(response.status, VerificationStatus::Failed);
+    assert!(response.result.is_none());
+    let error = response.error.expect("failed job carries an error");
+    assert!(error.retryable);
+    assert_eq!(error.code, "worker_crashed");
+}

--- a/crates/forall-hosted-verify/tests/wire_conformance.rs
+++ b/crates/forall-hosted-verify/tests/wire_conformance.rs
@@ -22,8 +22,7 @@ fn fixture(name: &str) -> String {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/wire")
         .join(name);
-    std::fs::read_to_string(&path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", path.display()))
+    std::fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()))
 }
 
 fn parse(name: &str) -> StatusVerificationResponse {


### PR DESCRIPTION
The public half of proof-view Phase 0 (companion to astrio-labs/forall-core#132):

- **C in forall-authoring** — mirror of the forall-core change: `SourceLanguage::C`, `.c`/`.h` discovery in this copy's LazyLock regex style, control-flow keyword filtering, ACSL `//@` scaffolding shared with the Java arm. Keeps the two authoring copies aligned ahead of the next sync.
- **Wire-conformance twins** — byte-identical copies of the canonical server fixtures (`mcp-host/tests/fixtures/wire/` in forall-core) parsed with this crate's hand-mirrored DTOs, plus self-stability checks. Until the wire types share a crate, changing either side without the twin fixtures fails a test instead of shipping a silent break.

Tests: `cargo test -p forall-authoring` (24 green) and `cargo test -p forall-hosted-verify --test wire_conformance` (3 green).

Co-authored-by: Forall <311994675+astrio-forall[bot]@users.noreply.github.com>
