### PR TITLE
Public sync: evidence-ladder schema mirror + claim/evidence docs

### DIFF
--- a/crates/forall-authoring/src/mapping/schema.rs
+++ b/crates/forall-authoring/src/mapping/schema.rs
@@ -55,6 +55,71 @@ pub struct Mapping {
     pub requirements: Vec<Requirement>,
 }
 
+/// The evidence ladder: how strongly a requirement's claim is backed, ordered
+/// so per-path targets and CI ratchets can compare rungs (`Ord` is the
+/// feature, not a convenience). STALE is deliberately not a rung — it is a
+/// modifier computed from content drift against the recorded fingerprints,
+/// never stored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceLevel {
+    /// E0 — nothing links this requirement to code.
+    None,
+    /// E1 — the requirement maps to code; no machine evidence exists.
+    SpecTracked,
+    /// E2 — scenario coverage exists.
+    Tested,
+    /// E3 — a seeded property run passed.
+    PropertyTested,
+    /// E4 — a formal contract is attached (machine-checkable, not yet
+    /// discharged).
+    Contracted,
+    /// E5 — every obligation discharged by a prover.
+    Proved,
+}
+
+impl EvidenceLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EvidenceLevel::None => "none",
+            EvidenceLevel::SpecTracked => "spec_tracked",
+            EvidenceLevel::Tested => "tested",
+            EvidenceLevel::PropertyTested => "property_tested",
+            EvidenceLevel::Contracted => "contracted",
+            EvidenceLevel::Proved => "proved",
+        }
+    }
+}
+
+/// The ladder rung this requirement CLAIMS, derived from mapping fields
+/// alone. In a version-1 mapping the `verified`/`property_tested` booleans
+/// are agent-writable, so this is a statement of intent, not a certificate —
+/// the earned level lives in the verify ledger, which only `forall check`
+/// writes. The two are kept separate on purpose: a claim can never render as
+/// evidence.
+pub fn claimed_evidence_level(requirement: &Requirement) -> EvidenceLevel {
+    if requirement.verified {
+        return EvidenceLevel::Proved;
+    }
+    if requirement.contract.is_some() {
+        return EvidenceLevel::Contracted;
+    }
+    if requirement.property_tested {
+        return EvidenceLevel::PropertyTested;
+    }
+    if requirement
+        .scenarios
+        .as_ref()
+        .is_some_and(|scenarios| !scenarios.is_empty())
+    {
+        return EvidenceLevel::Tested;
+    }
+    if requirement.code.is_some() {
+        return EvidenceLevel::SpecTracked;
+    }
+    EvidenceLevel::None
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum IssueSeverity {
@@ -145,9 +210,9 @@ pub fn summarize_verification(requirements: &[Requirement]) -> VerificationSumma
 }
 
 pub fn validate_mapping(mapping: &Mapping) -> Result<(), String> {
-    if mapping.version != 1 {
+    if mapping.version != 1 && mapping.version != 2 {
         return Err(format!(
-            "mapping version must be 1, got {}",
+            "mapping version must be 1 or 2, got {}",
             mapping.version
         ));
     }
@@ -160,6 +225,17 @@ pub fn validate_mapping(mapping: &Mapping) -> Result<(), String> {
         }
         if req.requirement.is_empty() {
             return Err("requirement text must not be empty".to_string());
+        }
+        // Version 2 mappings carry intent only. Evidence levels are earned
+        // through `forall check` and recorded in the verify ledger — a
+        // hand-written claim in the mapping must be a validation error, or
+        // the ledger is just the old writable boolean with more steps.
+        if mapping.version >= 2 && (req.verified || req.property_tested) {
+            return Err(format!(
+                "requirement '{}' claims evidence (verified/property_tested) in a version-2 \
+                 mapping; evidence is derived from the verify ledger, not written by hand",
+                req.id
+            ));
         }
         if req.verified && req.property_tested {
             return Err(format!(
@@ -186,4 +262,96 @@ pub fn validate_mapping(mapping: &Mapping) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod evidence_ladder_tests {
+    use super::*;
+
+    fn requirement() -> Requirement {
+        Requirement {
+            id: "REQ-1".to_string(),
+            capability: "cap".to_string(),
+            requirement: "text".to_string(),
+            verified: false,
+            property_tested: false,
+            property: None,
+            code: None,
+            contract: None,
+            claimcheck: None,
+            scenarios: None,
+        }
+    }
+
+    #[test]
+    fn ladder_orders_rungs_for_ratchet_comparisons() {
+        assert!(EvidenceLevel::None < EvidenceLevel::SpecTracked);
+        assert!(EvidenceLevel::SpecTracked < EvidenceLevel::Tested);
+        assert!(EvidenceLevel::Tested < EvidenceLevel::PropertyTested);
+        assert!(EvidenceLevel::PropertyTested < EvidenceLevel::Contracted);
+        assert!(EvidenceLevel::Contracted < EvidenceLevel::Proved);
+    }
+
+    #[test]
+    fn claimed_level_takes_the_highest_rung_the_mapping_states() {
+        let mut req = requirement();
+        assert_eq!(claimed_evidence_level(&req), EvidenceLevel::None);
+
+        req.code = Some(CodeRef {
+            file: "src/a.c".to_string(),
+            symbols: vec!["f".to_string()],
+        });
+        assert_eq!(claimed_evidence_level(&req), EvidenceLevel::SpecTracked);
+
+        req.scenarios = Some(vec![ScenarioRef {
+            name: "s".to_string(),
+            kind: None,
+        }]);
+        assert_eq!(claimed_evidence_level(&req), EvidenceLevel::Tested);
+
+        req.property_tested = true;
+        assert_eq!(claimed_evidence_level(&req), EvidenceLevel::PropertyTested);
+
+        req.contract = Some("Bounds".to_string());
+        assert_eq!(claimed_evidence_level(&req), EvidenceLevel::Contracted);
+
+        req.property_tested = false;
+        req.verified = true;
+        assert_eq!(claimed_evidence_level(&req), EvidenceLevel::Proved);
+    }
+
+    #[test]
+    fn version_2_mappings_reject_hand_written_evidence_claims() {
+        let mut req = requirement();
+        req.verified = true;
+        let mapping = Mapping {
+            version: 2,
+            requirements: vec![req],
+        };
+        let err = validate_mapping(&mapping).unwrap_err();
+        assert!(err.contains("derived from the verify ledger"), "got: {err}");
+
+        // The same claim is legal in version 1 (legacy semantics).
+        let mut legacy_req = requirement();
+        legacy_req.verified = true;
+        let legacy = Mapping {
+            version: 1,
+            requirements: vec![legacy_req],
+        };
+        assert!(validate_mapping(&legacy).is_ok());
+
+        // A claim-free version-2 mapping validates.
+        let clean = Mapping {
+            version: 2,
+            requirements: vec![requirement()],
+        };
+        assert!(validate_mapping(&clean).is_ok());
+
+        // Unknown versions still fail closed.
+        let future = Mapping {
+            version: 3,
+            requirements: Vec::new(),
+        };
+        assert!(validate_mapping(&future).is_err());
+    }
 }

--- a/crates/forall-authoring/src/mapping/schema.rs
+++ b/crates/forall-authoring/src/mapping/schema.rs
@@ -33,9 +33,9 @@ pub struct Requirement {
     pub id: String,
     pub capability: String,
     pub requirement: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub verified: bool,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub property_tested: bool,
     #[serde(default)]
     pub property: Option<PropertyRef>,
@@ -262,6 +262,36 @@ pub fn validate_mapping(mapping: &Mapping) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod serialization_tests {
+    use super::*;
+
+    #[test]
+    fn false_flags_are_not_serialized_so_v2_files_stay_flag_free() {
+        // Version-2 mappings drop the claim flags entirely; a serde
+        // round-trip (migrate, archive merge) must not reintroduce
+        // `verified: false` noise into files the docs call flag-free.
+        let mapping = Mapping {
+            version: 2,
+            requirements: vec![Requirement {
+                id: "R".to_string(),
+                capability: "cap".to_string(),
+                requirement: "text".to_string(),
+                verified: false,
+                property_tested: false,
+                property: None,
+                code: None,
+                contract: None,
+                claimcheck: None,
+                scenarios: None,
+            }],
+        };
+        let yaml = serde_yaml::to_string(&mapping).unwrap();
+        assert!(!yaml.contains("verified"), "got: {yaml}");
+        assert!(!yaml.contains("property_tested"), "got: {yaml}");
+    }
 }
 
 #[cfg(test)]

--- a/skills/forall-mcp-verify/SKILL.md
+++ b/skills/forall-mcp-verify/SKILL.md
@@ -154,7 +154,7 @@ User-facing language: **Forall verified** / **machine-checked**.
 ## Guardrails
 
 - Never claim success from an empty mapping / structure-only pass
-- Never downgrade `verified: true` to silence failures
+- Never downgrade `verified: true` to silence failures — the flag is proof scope; earned outcomes live in the report's `ledger` (claimed vs earned levels, per-obligation prover identity) and hosted results now include it
 - Prefer GitHub source when the revision is already public
 - Keep API keys out of the repo and chat logs
 - Cancel long jobs with `forall_cancel_verification` if the user aborts

--- a/skills/references/java.md
+++ b/skills/references/java.md
@@ -56,4 +56,4 @@ Avoid until core lemmas pass:
 1. Read hosted `proofs` issues / `proof_detail`
 2. Simplify ensures; split methods if needed
 3. Keep hard array logic spec-tracked temporarily
-4. Never flip `verified: true` → false only to silence failures on core logic
+4. Never flip `verified: true` → false to silence failures — the flag is proof scope; the ledger records what was actually earned either way

--- a/skills/references/layout.md
+++ b/skills/references/layout.md
@@ -32,7 +32,7 @@ context: |
   Author mapping and contracts locally; verify with forall_verify.
 rules:
   verification:
-    - Keep verified: true requirements machine-checked before claiming success
+    - Report proof status from the verify ledger, never from mapping flags
     - Prefer hosted forall_verify over skipping formal checks
 ```
 

--- a/skills/references/mapping.md
+++ b/skills/references/mapping.md
@@ -6,12 +6,15 @@ File: `.forall/verify/mapping.yaml` (project) or
 ## Top level
 
 ```yaml
-version: 1
+version: 2
 requirements:
   - id: ...
 ```
 
-`version` must be `1`.
+`version` is `1` (legacy: claim flags allowed as scope markers) or `2`
+(current: flag-free; evidence comes only from the verify ledger).
+Migrate a v1 mapping with `forall mapping migrate`. In a version-2 file,
+writing `verified:`/`property_tested:` is a validation error.
 
 ## Requirement fields
 

--- a/skills/references/mapping.md
+++ b/skills/references/mapping.md
@@ -20,8 +20,8 @@ requirements:
 | `id` | yes | Stable kebab-case id |
 | `capability` | yes | Grouping label |
 | `requirement` | yes | One-sentence SHALL |
-| `verified` | no (default false) | Formal proof required |
-| `property_tested` | no | Property-test required |
+| `verified` | no (default false) | Proof SCOPE marker (v1): intent, not evidence |
+| `property_tested` | no | Property-test scope marker (v1) |
 | `code.file` | for verify/PBT | Repo-relative source path |
 | `code.symbols` | for verify/PBT | Function / method names |
 | `contract` | recommended | Human-readable pre/post sketch |
@@ -32,11 +32,19 @@ requirements:
 
 ## Tiers
 
-1. **Proved** — `verified: true` + contracts in source + proofs phase pass
-2. **Property-tested** — `property_tested: true` + scenario file pass
-3. **Spec-tracked** — mapped only (`verified: false`, no PBT)
+Tiers are EARNED by `forall check` and recorded in the verify ledger
+(`*-ledger.json` beside the verify reports) — the mapping's flags state
+scope, never outcomes. Version-2 mappings (`forall mapping migrate`) drop
+the flags entirely; evidence levels come only from the ledger.
 
-Default for finite deterministic logic: **proved**.
+1. **Proved** — every proof obligation discharged in the latest check
+2. **Property-tested** — seeded property run passed
+3. **Spec-tracked** — mapped, no machine evidence yet
+
+Default scope for finite deterministic logic: **proved**. Never edit
+`*-ledger.json` by hand — it is sealed, and a hand-edited ledger reads as
+no evidence at all. Report proof status from the ledger and verify
+report, not from mapping flags.
 
 ## Examples
 

--- a/skills/references/rust.md
+++ b/skills/references/rust.md
@@ -65,5 +65,5 @@ code:
 1. Fix `requires` / `ensures` or the body
 2. Keep proofs honest — no unproven `assume`
 3. Re-run hosted `forall_verify`
-4. Do not downgrade `verified: true` because proofs are hard; simplify the
+4. Do not downgrade `verified: true` because proofs are hard (the ledger records earned outcomes regardless); simplify the
    contract or shrink the verified surface

--- a/skills/references/typescript.md
+++ b/skills/references/typescript.md
@@ -49,4 +49,4 @@ code:
 
 1. Read `proofs` phase issues from hosted status
 2. Tighten `//@ requires` / `//@ ensures` or fix the implementation
-3. Re-verify — do not flip `verified: false` to silence failures
+3. Re-verify — `verified` marks proof scope; evidence lives in the sealed verify ledger, so flipping the flag changes intent, never outcomes


### PR DESCRIPTION
Unblocked by #151. Two things the public mirror owed the closed repo:

- **Schema mirror**: `crates/forall-authoring` `mapping/schema.rs` is byte-identical with forall-core again — the `EvidenceLevel` ladder, `claimed_evidence_level`, v2 validation (hand-written claims rejected), plus the ladder tests.
- **Docs rewrite**: the reference docs and MCP skill stop presenting `verified: true` as an outcome. The flag states proof **scope**; evidence is earned by `forall check` into the sealed verify ledger (now visible in hosted results per #152); v2 mappings drop the flags entirely via `forall mapping migrate`; `*-ledger.json` is never hand-edited; proof status reports from the ledger. Matches the closed-side framing shipped in forall-core#137.

Tests: 27 authoring + 16 hosted-verify green; clippy-strict clean.

Co-authored-by: Forall <311994675+astrio-forall[bot]@users.noreply.github.com>