### PR TITLE
forall-wire: contract version 2 with requirement-scoped verification

### DIFF
--- a/crates/forall-hosted-verify/src/tests.rs
+++ b/crates/forall-hosted-verify/src/tests.rs
@@ -155,6 +155,7 @@ async fn initializes_session_and_calls_all_hosted_tools() {
             phases: vec![VerificationPhase::Proofs],
             pbt_seed: None,
             pbt_examples: None,
+            requirement_ids: None,
         })
         .await
         .expect("submit");

--- a/crates/forall-hosted-verify/tests/fixtures/wire/failed_status.json
+++ b/crates/forall-hosted-verify/tests/fixtures/wire/failed_status.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 1,
+  "contract_version": 2,
   "job_id": "job_7b6c5d4e3f2a",
   "status": "failed",
   "submitted_at": "2026-08-02T18:04:05Z",

--- a/crates/forall-hosted-verify/tests/fixtures/wire/running_status.json
+++ b/crates/forall-hosted-verify/tests/fixtures/wire/running_status.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 1,
+  "contract_version": 2,
   "job_id": "job_0c1d2e3f4a5b",
   "status": "running",
   "submitted_at": "2026-08-02T18:04:05Z",

--- a/crates/forall-hosted-verify/tests/fixtures/wire/succeeded_status.json
+++ b/crates/forall-hosted-verify/tests/fixtures/wire/succeeded_status.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 1,
+  "contract_version": 2,
   "job_id": "job_9f3a2c11d4e5",
   "status": "succeeded",
   "submitted_at": "2026-08-02T18:04:05Z",

--- a/crates/forall-hosted-verify/tests/standalone_flow.rs
+++ b/crates/forall-hosted-verify/tests/standalone_flow.rs
@@ -183,6 +183,7 @@ async fn authors_validates_packages_and_submits_without_a_local_mcp() {
             phases: Vec::new(),
             pbt_seed: Some(42),
             pbt_examples: Some(100),
+            requirement_ids: None,
         })
         .await
         .expect("hosted submit");

--- a/crates/forall-hosted-verify/tests/wire_conformance.rs
+++ b/crates/forall-hosted-verify/tests/wire_conformance.rs
@@ -73,7 +73,7 @@ fn parse(name: &str) -> StatusVerificationResponse {
 fn succeeded_status_parses_with_the_full_report() {
     let response = parse("succeeded_status.json");
 
-    assert_eq!(response.contract_version, 1);
+    assert_eq!(response.contract_version, 2);
     assert_eq!(response.status, VerificationStatus::Succeeded);
     assert_eq!(
         response.source_revision.as_deref(),

--- a/crates/forall-wire/src/lib.rs
+++ b/crates/forall-wire/src/lib.rs
@@ -83,6 +83,11 @@ pub struct SubmitVerificationRequest {
     pub pbt_seed: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pbt_examples: Option<u32>,
+    /// Verify only these requirements — incremental re-verification of a
+    /// changed requirement instead of a whole-project run. Absent means
+    /// every requirement. Requires contract version 2 on the server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requirement_ids: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
Public half of the batched bump (decision 3). Server half: astrio-labs/forall-core#153 — **deploy server-first**.

- **`VerifyRequest.requirement_ids`**: verify only the named requirements. The engine has always supported requirement-scoped plans; the hosted API pinned it off. This is what makes incremental re-verification of a single changed requirement possible instead of a whole-project run.
- **Why a version bump for one field**: request DTOs are `deny_unknown_fields`, so *any* new request field is a breaking change for already-deployed servers. Batching into one coordinated bump is the whole point — fixtures move to `contract_version: 2` in lockstep with their server twins.

**Deliberately excluded**: client-computed callee-contract hashes. The dependency-drift grading that would consume them doesn't exist yet (it needs call-graph extraction), and shipping a request field nothing reads is worse than a later second bump — I'd rather spend the breaking window on something real.