### PR TITLE
README: say which evidence each language can actually reach

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,35 @@ Your coding agent edits the workspace from verify reports. See [docs/getting-sta
 
 ## Supported programming languages
 
-- TypeScript
-- Java
-- Rust
-- C
+Forall grades every requirement by the strongest evidence a machine actually
+produced for it. Not every rung is reachable in every language, because the
+rung depends on the tool behind it:
 
-We are expanding to more languages based on demand.
+| | Spec tracked | Property tested | Contracted | Proved |
+| --- | :---: | :---: | :---: | :---: |
+| **TypeScript** | ✓ | ✓ | ✓ | ✓ |
+| **Python** | ✓ | ✓ | ✓ | ✗ |
+| **Rust** | ✓ | ✗ | ✓ | ✓ |
+| **Java** | ✓ | ✗ | ✓ | ✓ |
+| **C** | ✓ | ✗ | ✓ | ✓ |
+
+- **Spec tracked** — a requirement cites this code.
+- **Property tested** — a generator ran over many inputs and found no
+  counterexample. Statistical evidence, honestly ranked below a proof.
+- **Contracted** — a machine-checkable contract is written against the code,
+  but nothing has confirmed it yet.
+- **Proved** — a prover discharged that contract's obligations.
+
+`Proved` comes from a prover, one per language: LemmaScript → Dafny for
+TypeScript, Verus for Rust, OpenJML for Java, and Frama-C for C. Python has no
+prover, so property tests are its strongest rung.
+
+`Property tested` runs on the bundled Node and Python runners, which is why it
+is available for TypeScript and Python only. The generator library itself —
+fast-check or Hypothesis — is your project's own dependency.
+
+We are expanding to more languages, and to more rungs within the languages
+already listed, based on demand.
 
 ## Telemetry
 


### PR DESCRIPTION
Replaces the **Supported programming languages** list with a rung-by-language matrix.

| | Spec tracked | Property tested | Contracted | Proved |
| --- | :---: | :---: | :---: | :---: |
| **TypeScript** | ✓ | ✓ | ✓ | ✓ |
| **Python** | ✓ | ✓ | ✓ | ✗ |
| **Rust** | ✓ | ✗ | ✓ | ✓ |
| **Java** | ✓ | ✗ | ✓ | ✓ |
| **C** | ✓ | ✗ | ✓ | ✓ |

## Why

The old list was four language names. It could not answer the question a reader actually has — *what will Forall do for my code?* — and it **omitted Python entirely**, even though Python reaches three of the four rungs. Everything except a proof.

The matrix also makes the shape of the gaps visible, which the list hid: `Proved` needs a prover, and there is one per language (LemmaScript → Dafny, Verus, OpenJML, Frama-C) with none for Python. `Property tested` rides the bundled Node and Python runners, so it is TypeScript and Python only, and the generator library — fast-check or Hypothesis — is the project's own dependency.

## Why `Tested` is not a column

The matrix I drew this from had five rungs. `Tested` is deliberately dropped, because it is currently **unreachable**:

- `earned_level_for` has no `Tested` branch — zero occurrences in `ledger.rs`
- `run_scenario_tests` returns only `Vec<VerifyIssue>` and emits no obligations, so a passing scenario test produces no ledger entry and earns no rung
- a scenario listed in `mapping.yaml` can be `kind: manual`, and still claims the rung

So the scenario phase can fail a build but can never credit one. Publishing a column nobody can reach would have been the least honest part of the table.

Verified: 7 table rows, consistent column count, definitions render as a list rather than collapsing into one paragraph.