### PR TITLE
Docs: LemmaScript needs \result, not result

### DIFF
--- a/skills/references/typescript.md
+++ b/skills/references/typescript.md
@@ -9,7 +9,7 @@ Place annotations **inside** the function:
 ```ts
 export function clamp(x: number, lo: number, hi: number): number {
   //@ requires lo <= hi
-  //@ ensures lo <= result && result <= hi
+  //@ ensures lo <= \result && \result <= hi
   //@ contract Bounds clamp
   if (x < lo) return lo;
   if (x > hi) return hi;
@@ -19,7 +19,9 @@ export function clamp(x: number, lo: number, hi: number): number {
 
 Notes:
 
-- Use `result` for the return value in ensures
+- Use `\result` for the return value in ensures. The leading backslash is
+  required, and a bare `result` is parsed as an ordinary identifier, so the
+  proof fails with `unresolved identifier: result` rather than a syntax error
 - Keep predicates decidable and local to the function
 - Avoid I/O, DOM, and network inside verified functions
 


### PR DESCRIPTION
`skills/references/typescript.md` showed

```ts
//@ ensures lo <= result && result <= hi
```

and told the reader to *"use `result` for the return value in ensures"*.

LemmaScript only accepts the backslash form. From the installed parser, `tools/dist/specparser.js:14`:

```js
if (input[i] === "\\" && input.slice(i + 1, i + 7) === "result") {
    tokens.push({ type: "result", value: undefined });
```

A bare `result` falls through to the ordinary identifier path.

## Why this one is worth fixing carefully

The resulting failure does not point at the annotation. `lsc` emits a lemma with an unbound name and **Dafny** rejects the generated file:

```
pricing.dfy(13,16): Error: unresolved identifier: result
2 resolution/type errors detected in pricing.dfy
```

So a reader who follows this page is sent to debug generated Dafny for a mistake the documentation told them to make. An agent building a greenfield TypeScript project from these docs lost a full authoring cycle to exactly this.

## Only TypeScript is wrong

Checked all four language references before changing anything:

| file | uses | correct? |
|---|---|---|
| `java.md` | `\result` | ✅ JML syntax |
| `rust.md` | `result` | ✅ Verus names the result binding in the signature |
| `typescript.md` | `result` | ❌ fixed here |
| `mapping.md` | `result` | ✅ the `contract:` field is the mapping's own descriptive form, identical across all three languages |

So this is a one-file change, not a sweep — `rust.md`'s bare `result` would have been wrong to "fix".

The note now also says what the failure looks like, so anyone who hits it from an older doc or an existing file recognises it.